### PR TITLE
chore: update docs script to skip error checking in typedoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prebuild": "npm run lint",
     "build": "tsc --build --verbose tsconfig.build.json",
     "test": "node --test  --test-reporter=spec  --import tsx  --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=test-report.xml './packages/*/test/**/*.test.ts'",
-    "docs": "typedoc"
+    "docs": "typedoc --skipErrorChecking"
   },
   "license": "MIT",
   "workspaces": [


### PR DESCRIPTION
seems like typedoc do not pick up the tsconfig from the samples. As we are already building/validating the samples we can run typedoc with this flag