### PR TITLE
Update Adaptive Card handling: make 'id' optional and enhance action execution

### DIFF
--- a/packages/agents-activity/src/invoke/adaptiveCardInvokeAction.ts
+++ b/packages/agents-activity/src/invoke/adaptiveCardInvokeAction.ts
@@ -32,7 +32,7 @@ export interface AdaptiveCardInvokeAction {
  */
 export const adaptiveCardInvokeActionZodSchema = z.object({
   type: z.string().min(1),
-  id: z.string().min(1),
+  id: z.string().optional(),
   verb: z.string().min(1),
   data: z.record(z.string().min(1), z.any())
 })

--- a/packages/agents-activity/src/invoke/adaptiveCardInvokeAction.ts
+++ b/packages/agents-activity/src/invoke/adaptiveCardInvokeAction.ts
@@ -16,7 +16,7 @@ export interface AdaptiveCardInvokeAction {
   /**
    * The unique identifier of the action.
    */
-  id: string
+  id?: string
   /**
    * The verb associated with the action.
    */

--- a/packages/agents-hosting-teams/src/app/adaptive-cards/adaptiveCards.ts
+++ b/packages/agents-hosting-teams/src/app/adaptive-cards/adaptiveCards.ts
@@ -45,7 +45,7 @@ export class AdaptiveCards<TState extends TurnState> {
                         (invokeAction.action.type !== ACTION_EXECUTE_TYPE)
           ) {
             throw new Error(
-                            `Unexpected AdaptiveCards.actionExecute() triggered for activity type: ${a?.type}`
+                            `Unexpected AdaptiveCards.actionExecute() triggered for activity type: ${invokeAction.action.type}`
             )
           }
 

--- a/packages/agents-hosting-teams/src/app/adaptive-cards/adaptiveCards.ts
+++ b/packages/agents-hosting-teams/src/app/adaptive-cards/adaptiveCards.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Activity, ActivityTypes, AdaptiveCardInvokeAction, AdaptiveCardInvokeResponse, CardFactory, INVOKE_RESPONSE_KEY, InvokeResponse, MessageFactory, RouteSelector, TurnContext, TurnState } from '@microsoft/agents-hosting'
+import { Activity, ActivityTypes, AdaptiveCardInvokeResponse, CardFactory, INVOKE_RESPONSE_KEY, InvokeResponse, MessageFactory, RouteSelector, TurnContext, TurnState } from '@microsoft/agents-hosting'
 import { AdaptiveCard } from './adaptiveCard'
 import { TeamsApplication } from '../teamsApplication'
 import { AdaptiveCardActionExecuteResponseType } from './adaptiveCardActionExecuteResponseType'
@@ -38,17 +38,18 @@ export class AdaptiveCards<TState extends TurnState> {
         selector,
         async (context, state) => {
           const a = context?.activity
+          const invokeAction = parseValueActionExecuteSelector(a.value)
           if (
             a?.type !== ActivityTypes.Invoke ||
                         a?.name !== ACTION_INVOKE_NAME ||
-                        (a?.value as AdaptiveCardInvokeAction).type !== ACTION_EXECUTE_TYPE
+                        (invokeAction.action.type !== ACTION_EXECUTE_TYPE)
           ) {
             throw new Error(
                             `Unexpected AdaptiveCards.actionExecute() triggered for activity type: ${a?.type}`
             )
           }
 
-          const result = await handler(context, state, (parseAdaptiveCardInvokeAction(a.value)).data as TData ?? {} as TData)
+          const result = await handler(context, state, (invokeAction.action as TData) ?? {} as TData)
           if (!context.turnState.get(INVOKE_RESPONSE_KEY)) {
             let response: AdaptiveCardInvokeResponse
             if (typeof result === 'string') {

--- a/packages/agents-hosting-teams/test/activity-value-parsers/validateAdaptiveCardInvokeAction.test.ts
+++ b/packages/agents-hosting-teams/test/activity-value-parsers/validateAdaptiveCardInvokeAction.test.ts
@@ -38,15 +38,17 @@ describe('parseAdaptiveCardInvokeAction test', () => {
     }, ZodError)
   })
 
-  it('Should throw with no id', () => {
+  it('Should not throw without id', () => {
     const adaptiveCardInvokeActionObject = {
       type: 'type',
       verb: 'verb',
       data: { x: 'data' }
     }
-    assert.throws(() => {
-      parseAdaptiveCardInvokeAction(adaptiveCardInvokeActionObject)
-    }, ZodError)
+    const result = parseAdaptiveCardInvokeAction(adaptiveCardInvokeActionObject)
+    assert.equal(result.id, undefined)
+    assert.equal(result.type, 'type')
+    assert.equal(result.verb, 'verb')
+    assert.deepEqual(result.data, { x: 'data' })
   })
 
   it('Should throw with no string id', () => {

--- a/test-agents/teams-application-style/src/teamsApp.ts
+++ b/test-agents/teams-application-style/src/teamsApp.ts
@@ -3,6 +3,7 @@
 
 import {
   ActivityTypes,
+  CardFactory,
   CloudAdapter,
   ConversationParameters,
   MessageFactory,
@@ -11,10 +12,33 @@ import {
 }
   from '@microsoft/agents-hosting'
 import { TeamsInfo, TeamsMember, MeetingNotification, parseTeamsChannelData, TeamsApplication } from '@microsoft/agents-hosting-teams'
+import { AdaptiveCard } from '@microsoft/agents-hosting-teams/dist/src/app/adaptive-cards'
 
 type ApplicationTurnState = TurnState
 export const app = new TeamsApplication({
   removeRecipientMention: false
+})
+
+app.adaptiveCards.actionExecute('doStuff', async (context, state, data) => {
+  const card = {
+    type: 'AdaptiveCard',
+    body: [
+      {
+        type: 'TextBlock',
+        size: 'Medium',
+        weight: 'Bolder',
+        text: '✅[ACK] Test'
+      },
+      {
+        type: 'TextBlock',
+        text: 'doStuff action executed',
+        wrap: true
+      }
+    ],
+    $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
+    version: '1.4'
+  }
+  return card as AdaptiveCard
 })
 
 app.conversationUpdate('membersAdded', async (context: TurnContext, state: ApplicationTurnState) => {
@@ -25,6 +49,35 @@ app.conversationUpdate('membersAdded', async (context: TurnContext, state: Appli
       await context.sendActivity(MessageFactory.text(welcomeText, welcomeText))
     }
   }
+})
+
+app.message('/acInvoke', async (context: TurnContext, state: ApplicationTurnState) => {
+  const card = {
+    type: 'AdaptiveCard',
+    body: [
+      {
+        type: 'TextBlock',
+        size: 'Medium',
+        weight: 'Bolder',
+        text: 'Test Adaptive Card'
+      },
+      {
+        type: 'TextBlock',
+        text: 'Click the button to execute an action',
+        wrap: true
+      }
+    ],
+    actions: [
+      {
+        type: 'Action.Execute',
+        title: 'Do Stuff',
+        verb: 'doStuff'
+      }
+    ],
+    $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
+    version: '1.4'
+  }
+  await context.sendActivity(MessageFactory.attachment(CardFactory.adaptiveCard(card)))
 })
 
 app.message('/getMeetingParticipant', async (context: TurnContext, state: ApplicationTurnState) => {
@@ -142,6 +195,7 @@ app.activity(ActivityTypes.Message, async (context: TurnContext, state: Applicat
       /sendMessageToTeamsChannel,
       /sendMessageToListOfUsers,
       /sendMessageToAllUsersInTenant,
+      /acInvoke,
       /msgAllMembers`
     )])
 })


### PR DESCRIPTION
fixes #177

adds /acInvoke test case to teams test-agent
makes `id` inAdaptiveCardInvoke action as optional