### PR TITLE
Custom serialization to override bot/agent renames

### DIFF
--- a/packages/agents-activity/src/activity.ts
+++ b/packages/agents-activity/src/activity.ts
@@ -24,7 +24,7 @@ import { EndOfConversationCodes, endOfConversationCodesZodSchema } from './conve
 import { DeliveryModes, deliveryModesZodSchema } from './deliveryModes'
 import { Channels } from './conversation/channels'
 import { Mention } from './entity/mention'
-
+import { rep, rev } from './activityJsonOverrides'
 /**
  * Zod schema for validating an Activity object.
  */
@@ -149,7 +149,7 @@ export class Activity {
    * @returns The created Activity instance.
    */
   static fromJson (json: string): Activity {
-    return this.fromObject(JSON.parse(json))
+    return this.fromObject(JSON.parse(json, rev))
   }
 
   /**
@@ -178,7 +178,7 @@ export class Activity {
       locale: reference.locale,
       serviceUrl: reference.serviceUrl,
       conversation: reference.conversation,
-      recipient: reference.bot,
+      recipient: reference.agent,
       from: reference.user,
       relatesTo: reference
     }
@@ -223,7 +223,7 @@ export class Activity {
     return {
       activityId: this.getAppropriateReplyToId(),
       user: this.from,
-      bot: this.recipient,
+      agent: this.recipient,
       conversation: this.conversation,
       channelId: this.channelId,
       locale: this.locale,
@@ -247,12 +247,12 @@ export class Activity {
     this.conversation = reference.conversation
     if (isIncoming) {
       this.from = reference.user
-      this.recipient = reference.bot ?? undefined
+      this.recipient = reference.agent ?? undefined
       if (reference.activityId) {
         this.id = reference.activityId
       }
     } else {
-      this.from = reference.bot ?? undefined
+      this.from = reference.agent ?? undefined
       this.recipient = reference.user
       if (reference.activityId) {
         this.replyToId = reference.activityId
@@ -263,7 +263,7 @@ export class Activity {
   }
 
   public clone (): Activity {
-    const activityCopy = JSON.parse(JSON.stringify(this))
+    const activityCopy = JSON.parse(JSON.stringify(this, rep))
 
     for (const key in activityCopy) {
       if (typeof activityCopy[key] === 'string' && !isNaN(Date.parse(activityCopy[key]))) {
@@ -330,5 +330,9 @@ export class Activity {
     reference.activityId = replyId
 
     return reference
+  }
+
+  public toJsonString (): string {
+    return JSON.stringify(this, rep)
   }
 }

--- a/packages/agents-activity/src/activityJsonOverrides.ts
+++ b/packages/agents-activity/src/activityJsonOverrides.ts
@@ -1,0 +1,17 @@
+export function rep (k: string, v: any) {
+  if (typeof v === 'object' && v !== null && v['agent']) {
+    const ov = v['agent']
+    delete v['agent']
+    v['bot'] = ov
+  }
+  return v
+}
+
+export function rev (k: string, v: any) {
+  if (typeof v === 'object' && v !== null && v['bot']) {
+    const ov = v['bot']
+    delete v['bot']
+    v['agent'] = ov
+  }
+  return v
+}

--- a/packages/agents-activity/src/callerIdConstants.ts
+++ b/packages/agents-activity/src/callerIdConstants.ts
@@ -18,5 +18,5 @@ export const CallerIdConstants = {
   /**
    * Bot-to-bot prefix for caller ID.
    */
-  BotToBotPrefix: 'urn:botframework:aadappid:'
+  AgentPrefix: 'urn:botframework:aadappid:'
 }

--- a/packages/agents-activity/src/conversation/conversationReference.ts
+++ b/packages/agents-activity/src/conversation/conversationReference.ts
@@ -14,7 +14,7 @@ export interface ConversationReference {
   activityId?: string
   user?: ChannelAccount
   locale?: string
-  bot?: ChannelAccount | undefined | null
+  agent?: ChannelAccount | undefined | null
   conversation: ConversationAccount
   channelId: string
   serviceUrl?: string | undefined
@@ -27,7 +27,7 @@ export const conversationReferenceZodSchema = z.object({
   activityId: z.string().min(1).optional(),
   user: channelAccountZodSchema.optional(),
   locale: z.string().min(1).optional(),
-  bot: channelAccountZodSchema.optional().nullable(),
+  agent: channelAccountZodSchema.optional().nullable(),
   conversation: conversationAccountZodSchema,
   channelId: z.string().min(1),
   serviceUrl: z.string().min(1).optional()

--- a/packages/agents-activity/src/conversation/endOfConversationCodes.ts
+++ b/packages/agents-activity/src/conversation/endOfConversationCodes.ts
@@ -12,12 +12,12 @@ export enum EndOfConversationCodes {
   Unknown = 'unknown',
   CompletedSuccessfully = 'completedSuccessfully',
   UserCancelled = 'userCancelled',
-  BotTimedOut = 'botTimedOut',
-  BotIssuedInvalidMessage = 'botIssuedInvalidMessage',
+  AgentTimedOut = 'agentTimedOut',
+  AgentIssuedInvalidMessage = 'agentIssuedInvalidMessage',
   ChannelFailed = 'channelFailed',
 }
 
 /**
  * Zod schema for validating end of conversation codes.
  */
-export const endOfConversationCodesZodSchema = z.enum(['unknown', 'completedSuccessfully', 'userCancelled', 'botTimedOut', 'botIssuedInvalidMessage', 'channelFailed'])
+export const endOfConversationCodesZodSchema = z.enum(['unknown', 'completedSuccessfully', 'userCancelled', 'agentTimedOut', 'agentIssuedInvalidMessage', 'channelFailed'])

--- a/packages/agents-activity/src/conversation/roleTypes.ts
+++ b/packages/agents-activity/src/conversation/roleTypes.ts
@@ -10,7 +10,7 @@ import { z } from 'zod'
  */
 export enum RoleTypes {
   User = 'user',
-  Bot = 'bot',
+  Agent = 'bot',
   Skill = 'skill',
 }
 

--- a/packages/agents-activity/test/activity/activity.clone.test.ts
+++ b/packages/agents-activity/test/activity/activity.clone.test.ts
@@ -76,7 +76,7 @@ describe('Activity class', () => {
     const convRefExpected: ConversationReference = {
       activityId: 'activityId',
       user: clonedActivity.from,
-      bot: recipient,
+      agent: recipient,
       conversation,
       channelId,
       locale: clonedActivity.locale,

--- a/packages/agents-activity/test/activity/activity.test.ts
+++ b/packages/agents-activity/test/activity/activity.test.ts
@@ -345,7 +345,7 @@ describe('Activity object deserialization', () => {
     const from: ChannelAccount = {
       id: '123',
       name: 'myChannel',
-      role: RoleTypes.Bot
+      role: RoleTypes.Agent
     }
     const obj = {
       type: ActivityTypes.Message,
@@ -362,7 +362,7 @@ describe('Activity object deserialization', () => {
     assert.strictEqual(a1.from?.id, '123')
     assert.strictEqual(a1.from?.name, 'myChannel')
     assert.strictEqual(a1.from?.role, 'bot')
-    assert.strictEqual(a1.from?.role, RoleTypes.Bot)
+    assert.strictEqual(a1.from?.role, RoleTypes.Agent)
   })
 
   it('Deserialize with unknown type and text', () => {
@@ -698,7 +698,7 @@ describe('Activity getConversationReference', () => {
     const expected: ConversationReference = {
       activityId: 'activity123',
       user: { id: 'user1', name: 'User' },
-      bot: { id: 'bot1', name: 'Bot' },
+      agent: { id: 'bot1', name: 'Bot' },
       conversation: { id: 'conversation1' },
       channelId: 'channel123',
       locale: 'en-US',
@@ -720,7 +720,7 @@ describe('Activity applyConversationReference', () => {
     const reference: ConversationReference = {
       activityId: 'refActivityId',
       user: { id: 'user1', name: 'User' },
-      bot: { id: 'bot1', name: 'Bot' },
+      agent: { id: 'bot1', name: 'Bot' },
       conversation: { id: 'conversation1' },
       channelId: 'channel123',
       locale: 'en-US',
@@ -752,7 +752,7 @@ describe('Activity applyConversationReference', () => {
     const reference: ConversationReference = {
       activityId: 'refActivityId',
       user: { id: 'user1', name: 'User' },
-      bot: { id: 'bot1', name: 'Bot' },
+      agent: { id: 'bot1', name: 'Bot' },
       conversation: { id: 'conversation1' },
       channelId: 'channel123',
       locale: 'en-US',
@@ -783,7 +783,7 @@ describe('Activity applyConversationReference', () => {
     const reference: ConversationReference = {
       activityId: 'refActivityId',
       user: { id: 'user1', name: 'User' },
-      bot: null,
+      agent: null,
       conversation: { id: 'conversation1' },
       channelId: 'channel123',
       locale: 'en-US',
@@ -815,7 +815,7 @@ describe('Activity applyConversationReference', () => {
     const reference: ConversationReference = {
       activityId: 'refActivityId',
       user: { id: 'user1', name: 'User' },
-      bot: null,
+      agent: null,
       conversation: { id: 'conversation1' },
       channelId: 'channel123',
       locale: 'en-US',
@@ -928,7 +928,7 @@ describe('Activity getReplyConversationReference', () => {
     assert.deepEqual(result, {
       activityId: 'reply123',
       user: { id: 'user1', name: 'User' },
-      bot: { id: 'bot123', name: 'Bot' },
+      agent: { id: 'bot123', name: 'Bot' },
       conversation: { id: 'conversation1' },
       channelId: 'testChannel',
       serviceUrl: 'http://test.service.url',

--- a/packages/agents-activity/test/activity/callerIdConstants.test.ts
+++ b/packages/agents-activity/test/activity/callerIdConstants.test.ts
@@ -21,6 +21,6 @@ describe('CallerIdConstants', function () {
   it('CallerIdConstants.BotToBotPrefix should match value in botframework activity spec', function () {
     // Expected value derived from:
     // https://github.com/microsoft/botframework-sdk/blob/13be0336527fcc0e52d505ae38bd36a73742e74b/specs/botframework-activity/botframework-activity.md#bot-framework
-    assert.strictEqual(CallerIdConstants.BotToBotPrefix, 'urn:botframework:aadappid:')
+    assert.strictEqual(CallerIdConstants.AgentPrefix, 'urn:botframework:aadappid:')
   })
 })

--- a/packages/agents-activity/test/conversation/conversationReference.test.ts
+++ b/packages/agents-activity/test/conversation/conversationReference.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert'
 import { describe, it } from 'node:test'
 import { ChannelAccount, ConversationAccount, ConversationReference, RoleTypes } from '../../src'
 import { conversationReferenceZodSchema } from '../../src/conversation/conversationReference'
-
+import { rev } from '../../src/activityJsonOverrides'
 describe('ConversationReference', () => {
   it('should create a ConversationReference with valid properties', () => {
     const channelAccount: ChannelAccount = { id: '123', name: 'user1', role: RoleTypes.User }
@@ -21,7 +21,7 @@ describe('ConversationReference', () => {
       activityId: 'activityId',
       user: channelAccount,
       locale: 'locale',
-      bot: channelAccount,
+      agent: channelAccount,
       conversation: convAccount,
       channelId: 'channelId',
       serviceUrl: 'serviceUrl'
@@ -29,7 +29,7 @@ describe('ConversationReference', () => {
     assert.equal(conversationRef.activityId, 'activityId')
     assert.equal(conversationRef.user, channelAccount)
     assert.strictEqual(conversationRef.locale, 'locale')
-    assert.equal(conversationRef.bot, channelAccount)
+    assert.equal(conversationRef.agent, channelAccount)
     assert.strictEqual(conversationRef.conversation, convAccount)
     assert.strictEqual(conversationRef.channelId, 'channelId')
     assert.equal(conversationRef.serviceUrl, 'serviceUrl')
@@ -38,7 +38,7 @@ describe('ConversationReference', () => {
   it('should throw an error if bot is missing', () => {
     // @ts-expect-error
     const conversationRef: ConversationReference = { }
-    assert.strictEqual(conversationRef.bot, undefined)
+    assert.strictEqual(conversationRef.agent, undefined)
   })
 
   it('should throw an error if conversation is missing', () => {
@@ -100,11 +100,11 @@ describe('ConversationReference json deserialization', () => {
       role: RoleTypes.User,
       properties: 'test'
     }
-    const conversationRef: ConversationReference = conversationReferenceZodSchema.parse(JSON.parse(json))
+    const conversationRef: ConversationReference = conversationReferenceZodSchema.parse(JSON.parse(json, rev))
     assert.equal(conversationRef.activityId, 'activityId')
     assert.deepEqual(conversationRef.user, channelAccount)
     assert.strictEqual(conversationRef.locale, 'locale')
-    assert.deepEqual(conversationRef.bot, channelAccount)
+    assert.deepEqual(conversationRef.agent, channelAccount)
     assert.deepEqual(conversationRef.conversation, convAccount)
     assert.strictEqual(conversationRef.channelId, 'channelId')
     assert.equal(conversationRef.serviceUrl, 'serviceUrl')

--- a/packages/agents-hosting-teams/src/app/messaging-extension/messageExtensions.ts
+++ b/packages/agents-hosting-teams/src/app/messaging-extension/messageExtensions.ts
@@ -12,7 +12,7 @@ import { MessagingExtensionParameter } from '../../messaging-extension/messaging
 import { MessagingExtensionQuery } from '../../messaging-extension/messagingExtensionQuery'
 import { TaskModuleResponse } from '../../task/taskModuleResponse'
 import { MessageExtensionsInvokeNames } from './messageExtensionsInvokeNames'
-import { parseValueBotActivityPreview, parseValueBotMessagePreviewAction, parseValueCommandId, parseValueQuery } from '../../parsers'
+import { parseValueAgentActivityPreview, parseValueAgentMessagePreviewAction, parseValueCommandId, parseValueQuery } from '../../parsers'
 import { Query } from '../query'
 
 export class MessageExtensions<TState extends TurnState> {
@@ -66,7 +66,7 @@ export class MessageExtensions<TState extends TurnState> {
       this._app.addRoute(
         selector,
         async (context, state) => {
-          const activityValue = parseValueBotMessagePreviewAction(context.activity.value)
+          const activityValue = parseValueAgentMessagePreviewAction(context.activity.value)
           if (context?.activity?.type !== ActivityTypes.Invoke ||
             context?.activity?.name !== SUBMIT_ACTION_INVOKE ||
             activityValue.botMessagePreviewAction !== 'edit'
@@ -76,7 +76,7 @@ export class MessageExtensions<TState extends TurnState> {
             )
           }
 
-          const activityActivityPreview = parseValueBotActivityPreview(context.activity.value)
+          const activityActivityPreview = parseValueAgentActivityPreview(context.activity.value)
           const result = await handler(context, state, (activityActivityPreview as any).botActivityPreview[0] as Partial<Activity> ?? {})
           await this.returnSubmitActionResponse(context, result)
         },
@@ -96,7 +96,7 @@ export class MessageExtensions<TState extends TurnState> {
       this._app.addRoute(
         selector,
         async (context, state) => {
-          const activityMessagePreviewAction = parseValueBotMessagePreviewAction(context.activity.value)
+          const activityMessagePreviewAction = parseValueAgentMessagePreviewAction(context.activity.value)
           if (
             context?.activity?.type !== ActivityTypes.Invoke ||
                         context?.activity?.name !== SUBMIT_ACTION_INVOKE ||
@@ -107,7 +107,7 @@ export class MessageExtensions<TState extends TurnState> {
             )
           }
 
-          const activityActivityPreview = parseValueBotActivityPreview(context.activity.value)
+          const activityActivityPreview = parseValueAgentActivityPreview(context.activity.value)
           await handler(context, state, (activityActivityPreview as any).botActivityPreview[0] as Partial<Activity> ?? {})
 
           if (!context.turnState.get(INVOKE_RESPONSE_KEY)) {
@@ -474,7 +474,7 @@ function createTaskSelector (
 
 function matchesPreviewAction (activity: Activity, messagePreviewAction?: 'edit' | 'send'): boolean {
   if ('botMessagePreviewAction' in (activity?.value as any)) {
-    const activityValue = parseValueBotMessagePreviewAction(activity.value)
+    const activityValue = parseValueAgentMessagePreviewAction(activity.value)
     return activityValue.botMessagePreviewAction === messagePreviewAction
   } else {
     return messagePreviewAction === undefined

--- a/packages/agents-hosting-teams/src/parsers/activityValueParsers.ts
+++ b/packages/agents-hosting-teams/src/parsers/activityValueParsers.ts
@@ -190,7 +190,7 @@ export function parseValueQuery (value: unknown): {
  * @param {unknown} value - The value to parse.
  * @returns {object} - The parsed message preview action.
  */
-export function parseValueBotMessagePreviewAction (value: unknown): {
+export function parseValueAgentMessagePreviewAction (value: unknown): {
   botMessagePreviewAction: string;
 } {
   const botMessagePreviewActionZodSchema = z.object({
@@ -208,7 +208,7 @@ export function parseValueBotMessagePreviewAction (value: unknown): {
  * @param {unknown} value - The value to parse.
  * @returns {object} - The parsed activity preview.
  */
-export function parseValueBotActivityPreview (value: unknown): object {
+export function parseValueAgentActivityPreview (value: unknown): object {
   const botActivityPreviewZodSchema = z.object({
     botActivityPreview: z.array(activityZodSchema.partial())
   })

--- a/packages/agents-hosting-teams/src/teamsInfo.ts
+++ b/packages/agents-hosting-teams/src/teamsInfo.ts
@@ -134,7 +134,7 @@ export class TeamsInfo {
         },
       },
       activity,
-      bot: context.activity.recipient,
+      agent: context.activity.recipient,
     } as ConversationParameters
 
     let conversationReference: Partial<ConversationReference>

--- a/packages/agents-hosting-teams/test/activity-value-parsers/parseValueBotActivityPreview.test.ts
+++ b/packages/agents-hosting-teams/test/activity-value-parsers/parseValueBotActivityPreview.test.ts
@@ -1,7 +1,7 @@
 import assert from 'assert'
 import { describe, it } from 'node:test'
 import { ZodError } from 'zod'
-import { parseValueBotActivityPreview } from '../../src/parsers/activityValueParsers'
+import { parseValueAgentActivityPreview } from '../../src/parsers/activityValueParsers'
 import { ActivityTypes } from '@microsoft/agents-hosting'
 
 describe('parseValueBotActivityPreview test', () => {
@@ -18,7 +18,7 @@ describe('parseValueBotActivityPreview test', () => {
         }
       ]
     }
-    const parsedValue = parseValueBotActivityPreview(valueObject)
+    const parsedValue = parseValueAgentActivityPreview(valueObject)
     assert.deepEqual(parsedValue, valueObject)
   })
 
@@ -36,7 +36,7 @@ describe('parseValueBotActivityPreview test', () => {
       ]
     }
     assert.throws(() => {
-      parseValueBotActivityPreview(valueObject)
+      parseValueAgentActivityPreview(valueObject)
     }, ZodError)
   })
 })

--- a/packages/agents-hosting-teams/test/activity-value-parsers/parseValueBotMessagePreviewAction.test.ts
+++ b/packages/agents-hosting-teams/test/activity-value-parsers/parseValueBotMessagePreviewAction.test.ts
@@ -1,14 +1,14 @@
 import assert from 'assert'
 import { describe, it } from 'node:test'
 import { ZodError } from 'zod'
-import { parseValueBotMessagePreviewAction } from '../../src/parsers/activityValueParsers'
+import { parseValueAgentMessagePreviewAction } from '../../src/parsers/activityValueParsers'
 
 describe('parseValueBotMessagePreviewAction test', () => {
   it('Parse with all properties', () => {
     const valueObject = {
       botMessagePreviewAction: 'botMessagePreviewAction'
     }
-    const parsedValue = parseValueBotMessagePreviewAction(valueObject)
+    const parsedValue = parseValueAgentMessagePreviewAction(valueObject)
     assert.deepEqual(parsedValue, valueObject)
   })
 
@@ -17,7 +17,7 @@ describe('parseValueBotMessagePreviewAction test', () => {
       botMessagePreviewAction: 1
     }
     assert.throws(() => {
-      parseValueBotMessagePreviewAction(valueObject)
+      parseValueAgentMessagePreviewAction(valueObject)
     }, ZodError)
   })
 })

--- a/packages/agents-hosting/src/agent-client/agentClient.ts
+++ b/packages/agents-hosting/src/agent-client/agentClient.ts
@@ -56,7 +56,7 @@ export class AgentClient {
         Authorization: `Bearer ${token}`,
         'x-ms-conversation-id': activityCopy.conversation!.id
       },
-      body: JSON.stringify(activityCopy)
+      body: activityCopy.toJsonString()
     })
     if (!response.ok) {
       throw new Error(`Failed to post activity to agent: ${response.statusText}`)

--- a/packages/agents-hosting/src/agent-client/expressApi.ts
+++ b/packages/agents-hosting/src/agent-client/expressApi.ts
@@ -10,7 +10,7 @@ import { debug } from '../logger'
 const logger = debug('agents:agent-client')
 
 export const configureResponseController = (app: Application, adapter: CloudAdapter, agent: ActivityHandler) => {
-  app.post('/api/botresponse/v3/conversations/:conversationId/activities/:activityId', handleResponse(adapter, agent))
+  app.post('/api/agentresponse/v3/conversations/:conversationId/activities/:activityId', handleResponse(adapter, agent))
 }
 
 const handleResponse = (adapter: CloudAdapter, handler: ActivityHandler) => async (req: Request, res: Response) => {

--- a/packages/agents-hosting/src/auth/authConfiguration.ts
+++ b/packages/agents-hosting/src/auth/authConfiguration.ts
@@ -19,14 +19,17 @@ export interface AuthConfiguration {
 
 /**
  * Loads the authentication configuration from environment variables.
- * ```env
+ * ```
+ * tenantId=your-tenant-id
  * clientId=your-client-id
  * clientSecret=your-client-secret
- * tenantId=your-tenant-id
+ *
  * certPemFile=your-cert-pem-file
  * certKeyFile=your-cert-key-file
- * connectionName=your-connection-name
+ *
  * FICClientId=your-FIC-client-id
+ *
+ * connectionName=your-connection-name
  * ```
  * @remarks
  * - `clientId` is required
@@ -55,7 +58,7 @@ export const loadAuthConfigFromEnv: () => AuthConfiguration = () => {
 
 /**
  * Loads the agent authentication configuration from previouus version environment variables.
- * ```env
+ * ```
  * MicrosoftAppId=your-client-id
  * MicrosoftAppPassword=your-client-secret
  * MicrosoftAppTenantId=your-tenant-id

--- a/packages/agents-hosting/src/auth/authConfiguration.ts
+++ b/packages/agents-hosting/src/auth/authConfiguration.ts
@@ -19,6 +19,17 @@ export interface AuthConfiguration {
 
 /**
  * Loads the authentication configuration from environment variables.
+ * ```env
+ * clientId=your-client-id
+ * clientSecret=your-client-secret
+ * tenantId=your-tenant-id
+ * certPemFile=your-cert-pem-file
+ * certKeyFile=your-cert-key-file
+ * connectionName=your-connection-name
+ * FICClientId=your-FIC-client-id
+ * ```
+ * @remarks
+ * - `clientId` is required
  * @returns The authentication configuration.
  * @throws Will throw an error if clientId is not provided in production.
  */
@@ -43,11 +54,16 @@ export const loadAuthConfigFromEnv: () => AuthConfiguration = () => {
 }
 
 /**
- * Loads the agent authentication configuration from environment variables.
+ * Loads the agent authentication configuration from previouus version environment variables.
+ * ```env
+ * MicrosoftAppId=your-client-id
+ * MicrosoftAppPassword=your-client-secret
+ * MicrosoftAppTenantId=your-tenant-id
+ * ```
  * @returns The agent authentication configuration.
  * @throws Will throw an error if MicrosoftAppId is not provided in production.
  */
-export const loadBotAuthConfigFromEnv: () => AuthConfiguration = () => {
+export const loadPrevAuthConfigFromEnv: () => AuthConfiguration = () => {
   if (process.env.MicrosoftAppId === undefined && process.env.NODE_ENV === 'production') {
     throw new Error('ClientId required in production')
   }
@@ -61,8 +77,8 @@ export const loadBotAuthConfigFromEnv: () => AuthConfiguration = () => {
     FICClientId: process.env.MicrosoftAppClientId,
     issuers: [
       'https://api.botframework.com',
-        `https://sts.windows.net/${process.env.MicrosoftAppTenantId}/`,
-        `https://login.microsoftonline.com/${process.env.MicrosoftAppTenantId}/v2.0`
+      `https://sts.windows.net/${process.env.MicrosoftAppTenantId}/`,
+      `https://login.microsoftonline.com/${process.env.MicrosoftAppTenantId}/v2.0`
     ]
   }
 }

--- a/packages/agents-hosting/src/cloudAdapter.ts
+++ b/packages/agents-hosting/src/cloudAdapter.ts
@@ -339,7 +339,7 @@ export class CloudAdapter extends BaseAdapter {
       tenantId: conversationParameters.tenantId,
     }
     activity.channelData = conversationParameters.channelData
-    activity.recipient = conversationParameters.bot
+    activity.recipient = conversationParameters.agent
 
     return activity
   }

--- a/packages/agents-hosting/src/connector-client/conversationParameters.ts
+++ b/packages/agents-hosting/src/connector-client/conversationParameters.ts
@@ -16,7 +16,7 @@ export interface ConversationParameters {
   /**
    * The bot account initiating the conversation.
    */
-  bot: ChannelAccount
+  agent: ChannelAccount
   /**
    * The members to include in the conversation.
    */

--- a/packages/agents-hosting/test/activity-protocol/adapter/cloudAdapter.test.ts
+++ b/packages/agents-hosting/test/activity-protocol/adapter/cloudAdapter.test.ts
@@ -150,7 +150,7 @@ describe('CloudAdapter', function () {
       const conversationReference: ConversationReference = {
         activityId: '1234',
         user: { id: 'user1', name: 'User' },
-        bot: { id: 'bot1', name: 'Bot' },
+        agent: { id: 'bot1', name: 'Bot' },
         conversation: { id: 'conversation1' },
         channelId: 'channel123',
         locale: 'en-US',

--- a/packages/agents-hosting/test/activity-protocol/adapter/turnContext.test.ts
+++ b/packages/agents-hosting/test/activity-protocol/adapter/turnContext.test.ts
@@ -284,7 +284,7 @@ describe('TurnContext', { timeout: 5000 }, function () {
     const conversationReference: ConversationReference = {
       activityId: '1234',
       user: { id: 'user1', name: 'User' },
-      bot: { id: 'bot1', name: 'Bot' },
+      agent: { id: 'bot1', name: 'Bot' },
       conversation: { id: 'conversation1' },
       channelId: 'channel123',
       locale: 'en-US',

--- a/test-agents/empty-agent/src/agent.ts
+++ b/test-agents/empty-agent/src/agent.ts
@@ -17,7 +17,7 @@ export class EmptyAgent extends ActivityHandler {
           }
         ))
       } else {
-        const replyText = `agent: ${context.activity.text}`
+        const replyText = `empty-agent: ${context.activity.text}`
         await context.sendActivity(MessageFactory.text(replyText, replyText))
       }
       await next()

--- a/test-agents/empty-agent/src/index.ts
+++ b/test-agents/empty-agent/src/index.ts
@@ -23,7 +23,7 @@ app.post('/api/messages', async (req: Request, res: Response) => {
   await adapter.process(req, res, async (context) => await myAgent.run(context))
 })
 
-const port = process.env.PORT || 39783
+const port = process.env.PORT || 3978
 app.listen(port, () => {
   console.log(`\nServer listening to port ${port} on sdk ${sdkVersion} for appId ${authConfig.clientId} debug ${process.env.DEBUG}`)
 }).on('error', console.error)

--- a/test-agents/root-agent/env.TEMPLATE
+++ b/test-agents/root-agent/env.TEMPLATE
@@ -4,4 +4,4 @@ clientSecret=ssshhhhhhhhhhhh
 
 Agent1_endpoint=http://localhost:3978/api/messages
 Agent1_clientId=<targetbot_clientid>
-Agent1_serviceUrl=http://localhost:39783/api/botresponse
+Agent1_serviceUrl=http://localhost:39783/api/agentresponse

--- a/test-agents/teams-agent/src/teamsHandler.ts
+++ b/test-agents/teams-agent/src/teamsHandler.ts
@@ -115,7 +115,7 @@ export class TeamsHandler extends TeamsActivityHandler {
       const convoParams: ConversationParameters = {
         members: [{ id: member.id }],
         isGroup: false,
-        bot: context.activity.recipient!,
+        agent: context.activity.recipient!,
         tenantId: context.activity.conversation!.tenantId,
         activity: message,
         channelData: context.activity.channelData

--- a/test-agents/teams-application-style/src/teamsApp.ts
+++ b/test-agents/teams-application-style/src/teamsApp.ts
@@ -210,7 +210,7 @@ async function messageAllMembers (context: TurnContext) {
     const convoParams: ConversationParameters = {
       members: [{ id: member.id }],
       isGroup: false,
-      bot: context.activity.recipient!,
+      agent: context.activity.recipient!,
       tenantId: context.activity.conversation!.tenantId,
       activity: message,
       channelData: context.activity.channelData


### PR DESCRIPTION
fixes #202 
This pull request includes several changes to the `packages/agents-activity` and `packages/agents-hosting-teams` modules to replace references to "bot" with "agent" and to add JSON serialization overrides. The most important changes include updates to the `Activity` class, modifications to various test files, and the introduction of new JSON serialization functions.

### Updates to the `Activity` class:

* Updated the `fromJson` method to use the `rev` function for JSON parsing (`packages/agents-activity/src/activity.ts`, [packages/agents-activity/src/activity.tsL152-R152](diffhunk://#diff-1520d81a3e111c1eaa5cba3e1debfb5232bf126d6326d062bcf479e5062fe5a1L152-R152)).
* Changed references from `bot` to `agent` in the `Activity` class (`packages/agents-activity/src/activity.ts`, [[1]](diffhunk://#diff-1520d81a3e111c1eaa5cba3e1debfb5232bf126d6326d062bcf479e5062fe5a1L181-R181) [[2]](diffhunk://#diff-1520d81a3e111c1eaa5cba3e1debfb5232bf126d6326d062bcf479e5062fe5a1L226-R226) [[3]](diffhunk://#diff-1520d81a3e111c1eaa5cba3e1debfb5232bf126d6326d062bcf479e5062fe5a1L250-R255).
* Added the `toJsonString` method to the `Activity` class to use the `rep` function for JSON stringification (`packages/agents-activity/src/activity.ts`, [packages/agents-activity/src/activity.tsR334-R337](diffhunk://#diff-1520d81a3e111c1eaa5cba3e1debfb5232bf126d6326d062bcf479e5062fe5a1R334-R337)).

### Modifications to test files:

* Updated various test cases to replace `bot` with `agent` in `activity.clone.test.ts` and `activity.test.ts` (`packages/agents-activity/test/activity/activity.clone.test.ts`, [[1]](diffhunk://#diff-3f4db18010d1f13f8c751d46e2881144dbca323c7a43467ca3cf738463ba0413L79-R79); `packages/agents-activity/test/activity/activity.test.ts`, [[2]](diffhunk://#diff-c81d82e40d857f222997a85346cab83cef2cc994ee48031e2608aad1c4374993L348-R348) [[3]](diffhunk://#diff-c81d82e40d857f222997a85346cab83cef2cc994ee48031e2608aad1c4374993L365-R365) [[4]](diffhunk://#diff-c81d82e40d857f222997a85346cab83cef2cc994ee48031e2608aad1c4374993L701-R701) [[5]](diffhunk://#diff-c81d82e40d857f222997a85346cab83cef2cc994ee48031e2608aad1c4374993L723-R723) [[6]](diffhunk://#diff-c81d82e40d857f222997a85346cab83cef2cc994ee48031e2608aad1c4374993L755-R755) [[7]](diffhunk://#diff-c81d82e40d857f222997a85346cab83cef2cc994ee48031e2608aad1c4374993L786-R786) [[8]](diffhunk://#diff-c81d82e40d857f222997a85346cab83cef2cc994ee48031e2608aad1c4374993L818-R818) [[9]](diffhunk://#diff-c81d82e40d857f222997a85346cab83cef2cc994ee48031e2608aad1c4374993L931-R931).
* Updated the `CallerIdConstants` test to reflect the new `AgentPrefix` constant (`packages/agents-activity/test/activity/callerIdConstants.test.ts`, [packages/agents-activity/test/activity/callerIdConstants.test.tsL24-R24](diffhunk://#diff-f3b2a90fc6f70a9815e0bd68bdfbcd4db40fe1664ecb0427f070ef77a15b3370L24-R24)).
* Modified `conversationReference.test.ts` to use the `rev` function for JSON parsing and to replace `bot` with `agent` (`packages/agents-activity/test/conversation/conversationReference.test.ts`, [[1]](diffhunk://#diff-2d62903752de8884e8861f38d054ffaa23dc99dacb787a5ca470c766818c1e0aL5-R5) [[2]](diffhunk://#diff-2d62903752de8884e8861f38d054ffaa23dc99dacb787a5ca470c766818c1e0aL24-R32) [[3]](diffhunk://#diff-2d62903752de8884e8861f38d054ffaa23dc99dacb787a5ca470c766818c1e0aL41-R41) [[4]](diffhunk://#diff-2d62903752de8884e8861f38d054ffaa23dc99dacb787a5ca470c766818c1e0aL103-R107).

### JSON serialization overrides:

* Added `rep` and `rev` functions for custom JSON serialization and deserialization to handle the `agent` property (`packages/agents-activity/src/activityJsonOverrides.ts`, [packages/agents-activity/src/activityJsonOverrides.tsR1-R17](diffhunk://#diff-3d598d1cbf55cb3a7c78728b0de305a8b668a22a4f99324029e5aee7cce9ad6dR1-R17)).

### Other changes:

* Updated `CallerIdConstants` to replace `BotToBotPrefix` with `AgentPrefix` (`packages/agents-activity/src/callerIdConstants.ts`, [packages/agents-activity/src/callerIdConstants.tsL21-R21](diffhunk://#diff-acef099730e72487b8c94a1dd8d6c8ff89853aeaccd42d25b1f91e9ce8bde83eL21-R21)).
* Modified `conversationReferenceZodSchema` to replace `bot` with `agent` (`packages/agents-activity/src/conversation/conversationReference.ts`, [packages/agents-activity/src/conversation/conversationReference.tsL30-R30](diffhunk://#diff-ad573551a9f60f3ee756522d84738ffd7919deda08559c57b37609e5cfc3d2ffL30-R30)).
* Updated `RoleTypes` to replace `Bot` with `Agent` (`packages/agents-activity/src/conversation/roleTypes.ts`, [packages/agents-activity/src/conversation/roleTypes.tsL13-R13](diffhunk://#diff-6e2ae81c2a7590ae54fe9a1b4230b5fed935d323e58e79ee179c7f7736fa7783L13-R13)).
* Replaced `parseValueBotActivityPreview` and `parseValueBotMessagePreviewAction` with `parseValueAgentActivityPreview` and `parseValueAgentMessagePreviewAction` in `messageExtensions.ts` (`packages/agents-hosting-teams/src/app/messaging-extension/messageExtensions.ts`, [[1]](diffhunk://#diff-e2e03f593627b0749dfa27f760214034ec5743e6a065e8338f45d65121d50b45L15-R15) [[2]](diffhunk://#diff-e2e03f593627b0749dfa27f760214034ec5743e6a065e8338f45d65121d50b45L69-R69) [[3]](diffhunk://#diff-e2e03f593627b0749dfa27f760214034ec5743e6a065e8338f45d65121d50b45L79-R79) [[4]](diffhunk://#diff-e2e03f593627b0749dfa27f760214034ec5743e6a065e8338f45d65121d50b45L99-R99).