### PR TITLE
Update lint strategy

### DIFF
--- a/.azdo/ci-pr.yaml
+++ b/.azdo/ci-pr.yaml
@@ -30,6 +30,9 @@ steps:
 - script: node setVersion.js
   displayName: set version
 
+- script: npm run lint
+  displayName: lint
+
 - script: npm run build
   displayName: build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies with CI
         run: npm ci
 
+      - name: lint
+        run: npm run lint
+        
       - name: Build TS
         run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -18,10 +18,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "lint": "eslint --fix",
+    "lint": "eslint",
     "clean": "git clean -xdf",
     "postclean": "npm ci",
-    "prebuild": "npm run lint",
     "build": "tsc --build --verbose tsconfig.build.json",
     "build:clean": "npm run clean && npm run build",
     "test": "node --test  --test-reporter=spec  --import tsx  --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=test-report.xml './packages/*/test/**/*.test.ts'",


### PR DESCRIPTION
running lint on every build slows down the inner loop.

removing the prebuild task and add explicit lint to pipelines