### PR TITLE
add product info to user agent

### DIFF
--- a/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
+++ b/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
@@ -83,7 +83,7 @@ export class CopilotStudioClient {
   private static getProductInfo (): string {
     const version = require('../../../package.json').version
     const os = require('os')
-    return `agents-sdk-js/${version} nodejs/${process.version}  ${os.platform()}-${os.arch()}/${os.release()}`
+    return `CopilotStudioClient.agents-sdk-js/${version} nodejs/${process.version}  ${os.platform()}-${os.arch()}/${os.release()}`
   }
 
   public async startConversationAsync (emitStartConversationEvent: boolean = true): Promise<Activity> {

--- a/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
+++ b/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
@@ -9,7 +9,7 @@ import { getCopilotStudioConnectionUrl } from './powerPlatformEnvironment'
 import { Activity, ActivityTypes, ConversationAccount } from '@microsoft/agents-activity'
 import { ExecuteTurnRequest } from './executeTurnRequest'
 import createDebug, { Debugger } from 'debug'
-import pjson from './../package.json'
+import pjson from '@microsoft/agents-copilotstudio-client/package.json'
 import os from 'os'
 
 interface streamRead {

--- a/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
+++ b/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
@@ -80,6 +80,12 @@ export class CopilotStudioClient {
     return activities
   }
 
+  private static getProductInfo (): string {
+    const version = require('../../../package.json').version
+    const os = require('os')
+    return `agents-sdk-js/${version} nodejs/${process.version}  ${os.platform()}-${os.arch()}/${os.release()}`
+  }
+
   public async startConversationAsync (emitStartConversationEvent: boolean = true): Promise<Activity> {
     const uriStart: string = getCopilotStudioConnectionUrl(this.settings)
     const body = { emitStartConversationEvent }
@@ -89,7 +95,8 @@ export class CopilotStudioClient {
       url: uriStart,
       headers: {
         Accept: 'text/event-stream',
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'User-Agent': CopilotStudioClient.getProductInfo(),
       },
       data: body,
       responseType: 'stream',

--- a/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
+++ b/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
@@ -9,6 +9,8 @@ import { getCopilotStudioConnectionUrl } from './powerPlatformEnvironment'
 import { Activity, ActivityTypes, ConversationAccount } from '@microsoft/agents-activity'
 import { ExecuteTurnRequest } from './executeTurnRequest'
 import createDebug, { Debugger } from 'debug'
+import pjson from './../package.json'
+import os from 'os'
 
 interface streamRead {
   done: boolean,
@@ -81,9 +83,7 @@ export class CopilotStudioClient {
   }
 
   private static getProductInfo (): string {
-    const version = require('../../../package.json').version
-    const os = require('os')
-    return `CopilotStudioClient.agents-sdk-js/${version} nodejs/${process.version}  ${os.platform()}-${os.arch()}/${os.release()}`
+    return `CopilotStudioClient.agents-sdk-js/${pjson.version} nodejs/${process.version}  ${os.platform()}-${os.arch()}/${os.release()}`
   }
 
   public async startConversationAsync (emitStartConversationEvent: boolean = true): Promise<Activity> {

--- a/packages/agents-hosting-teams/src/connector-client/teamsConnectorClient.ts
+++ b/packages/agents-hosting-teams/src/connector-client/teamsConnectorClient.ts
@@ -33,7 +33,8 @@ export class TeamsConnectorClient extends ConnectorClient {
     const axiosInstance = axios.create({
       baseURL,
       headers: {
-        Accept: 'application/json'
+        Accept: 'application/json',
+        'User-Agent': ConnectorClient.getProductInfo(),
       }
     })
 

--- a/packages/agents-hosting-teams/src/connector-client/teamsConnectorClient.ts
+++ b/packages/agents-hosting-teams/src/connector-client/teamsConnectorClient.ts
@@ -1,7 +1,7 @@
 /** * Copyright (c) Microsoft Corporation. All rights reserved. * Licensed under the MIT License. */
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios'
 import { Activity, ChannelAccount } from '@microsoft/agents-activity'
-import { ConnectorClient, AuthConfiguration, AuthProvider } from '@microsoft/agents-hosting'
+import { ConnectorClient, AuthConfiguration, AuthProvider, getProductInfo } from '@microsoft/agents-hosting'
 import { TeamsChannelAccount } from './teamsChannelAccount'
 import { TeamsPagedMembersResult } from './teamsPagedMembersResult'
 import { TeamDetails } from './teamDetails'
@@ -34,7 +34,7 @@ export class TeamsConnectorClient extends ConnectorClient {
       baseURL,
       headers: {
         Accept: 'application/json',
-        'User-Agent': ConnectorClient.getProductInfo(),
+        'User-Agent': getProductInfo(),
       }
     })
 

--- a/packages/agents-hosting/src/connector-client/connectorClient.ts
+++ b/packages/agents-hosting/src/connector-client/connectorClient.ts
@@ -70,7 +70,8 @@ export class ConnectorClient {
     const axiosInstance = axios.create({
       baseURL,
       headers: {
-        Accept: 'application/json'
+        Accept: 'application/json',
+        'User-Agent': ConnectorClient.getProductInfo(),
       },
       transformRequest: [
         (data, headers) => {
@@ -83,6 +84,12 @@ export class ConnectorClient {
       axiosInstance.defaults.headers.common.Authorization = `Bearer ${token}`
     }
     return new ConnectorClient(axiosInstance)
+  }
+
+  protected static getProductInfo (): string {
+    const version = require('../../../package.json').version
+    const os = require('os')
+    return `agents-sdk-js/${version} nodejs/${process.version}  ${os.platform()}-${os.arch()}/${os.release()}`
   }
 
   /**

--- a/packages/agents-hosting/src/connector-client/connectorClient.ts
+++ b/packages/agents-hosting/src/connector-client/connectorClient.ts
@@ -89,7 +89,7 @@ export class ConnectorClient {
   protected static getProductInfo (): string {
     const version = require('../../../package.json').version
     const os = require('os')
-    return `agents-sdk-js/${version} nodejs/${process.version}  ${os.platform()}-${os.arch()}/${os.release()}`
+    return `agents-sdk-js/${version} nodejs/${process.version} ${os.platform()}-${os.arch()}/${os.release()}`
   }
 
   /**

--- a/packages/agents-hosting/src/connector-client/connectorClient.ts
+++ b/packages/agents-hosting/src/connector-client/connectorClient.ts
@@ -10,6 +10,7 @@ import { ResourceResponse } from './resourceResponse'
 import { AttachmentInfo } from './attachmentInfo'
 import { AttachmentData } from './attachmentData'
 import { normalizeOutgoingActivity } from '../activityWireCompat'
+import { getProductInfo } from '../getProductInfo'
 const logger = debug('agents:connector-client')
 
 /**
@@ -71,7 +72,7 @@ export class ConnectorClient {
       baseURL,
       headers: {
         Accept: 'application/json',
-        'User-Agent': ConnectorClient.getProductInfo(),
+        'User-Agent': getProductInfo(),
       },
       transformRequest: [
         (data, headers) => {
@@ -84,12 +85,6 @@ export class ConnectorClient {
       axiosInstance.defaults.headers.common.Authorization = `Bearer ${token}`
     }
     return new ConnectorClient(axiosInstance)
-  }
-
-  protected static getProductInfo (): string {
-    const version = require('../../../package.json').version
-    const os = require('os')
-    return `agents-sdk-js/${version} nodejs/${process.version} ${os.platform()}-${os.arch()}/${os.release()}`
   }
 
   /**

--- a/packages/agents-hosting/src/connector-client/connectorClient.ts
+++ b/packages/agents-hosting/src/connector-client/connectorClient.ts
@@ -13,6 +13,8 @@ import { normalizeOutgoingActivity } from '../activityWireCompat'
 import { getProductInfo } from '../getProductInfo'
 const logger = debug('agents:connector-client')
 
+export { getProductInfo }
+
 /**
  * ConnectorClient is a client for interacting with the Microsoft Connector API.
  */

--- a/packages/agents-hosting/src/getProductInfo.ts
+++ b/packages/agents-hosting/src/getProductInfo.ts
@@ -1,0 +1,3 @@
+const version = require('../../../package.json').version
+const os = require('os')
+export const getProductInfo = () : string => `agents-sdk-js/${version} nodejs/${process.version} ${os.platform()}-${os.arch()}/${os.release()}`

--- a/packages/agents-hosting/src/getProductInfo.ts
+++ b/packages/agents-hosting/src/getProductInfo.ts
@@ -1,3 +1,3 @@
-const version = require('../../../package.json').version
-const os = require('os')
-export const getProductInfo = () : string => `agents-sdk-js/${version} nodejs/${process.version} ${os.platform()}-${os.arch()}/${os.release()}`
+import pjson from '../../../package.json'
+import os from 'os'
+export const getProductInfo = () : string => `agents-sdk-js/${pjson.version} nodejs/${process.version} ${os.platform()}-${os.arch()}/${os.release()}`

--- a/packages/agents-hosting/src/getProductInfo.ts
+++ b/packages/agents-hosting/src/getProductInfo.ts
@@ -1,3 +1,3 @@
-import pjson from '../../../package.json'
+import pjson from '@microsoft/agents-hosting/package.json'
 import os from 'os'
 export const getProductInfo = () : string => `agents-sdk-js/${pjson.version} nodejs/${process.version} ${os.platform()}-${os.arch()}/${os.release()}`

--- a/packages/agents-hosting/src/oauth/userTokenClient.ts
+++ b/packages/agents-hosting/src/oauth/userTokenClient.ts
@@ -6,8 +6,9 @@ import { SigningResource } from './signingResource'
 import { Activity } from '@microsoft/agents-activity'
 import { debug } from '../logger'
 import { TokenExchangeRequest } from './tokenExchangeRequest'
+import { getProductInfo } from '../getProductInfo'
 
-const logger = debug('agents:userTokenClient')
+const logger = debug('agents:user-token-client')
 
 /**
  * Client for managing user tokens.
@@ -24,7 +25,8 @@ export class UserTokenClient {
     const axiosInstance = axios.create({
       baseURL,
       headers: {
-        Accept: 'application/json'
+        Accept: 'application/json',
+        'User-Agent': getProductInfo(),
       }
     })
     axiosInstance.defaults.headers.common.Authorization = `Bearer ${token}`


### PR DESCRIPTION
This pull request introduces several changes to add a `User-Agent` header with product information to HTTP requests across multiple client classes. The most important changes include the addition of a `getProductInfo` method to fetch version and OS details, and the inclusion of this information in the `User-Agent` header for HTTP requests.

### Additions to `User-Agent` header:

* [`packages/agents-copilotstudio-client/src/copilotStudioClient.ts`](diffhunk://#diff-dccb8043377a8daf37d9aee1350a56d2ffe9ae50752837646410964c699ba173R83-R88): Added a `getProductInfo` method to return a string with version and OS details, and included this information in the `User-Agent` header for HTTP requests. [[1]](diffhunk://#diff-dccb8043377a8daf37d9aee1350a56d2ffe9ae50752837646410964c699ba173R83-R88) [[2]](diffhunk://#diff-dccb8043377a8daf37d9aee1350a56d2ffe9ae50752837646410964c699ba173L92-R99)
* [`packages/agents-hosting-teams/src/connector-client/teamsConnectorClient.ts`](diffhunk://#diff-afb125a44bbab410ff3b24418476fa5a2c617a863fa650c6b8b2af0d8d3726d5L36-R37): Included the product information in the `User-Agent` header for HTTP requests by calling the `getProductInfo` method from the `ConnectorClient` class.
* [`packages/agents-hosting/src/connector-client/connectorClient.ts`](diffhunk://#diff-2e8863008604a8febac825f545e49f081bf7d5d5a67046e25164b4fc7da0fa74L73-R74): Added a `getProductInfo` method to return a string with version and OS details, and included this information in the `User-Agent` header for HTTP requests. [[1]](diffhunk://#diff-2e8863008604a8febac825f545e49f081bf7d5d5a67046e25164b4fc7da0fa74L73-R74) [[2]](diffhunk://#diff-2e8863008604a8febac825f545e49f081bf7d5d5a67046e25164b4fc7da0fa74R89-R94)fixes #46