### PR TITLE
refactor: update entity schema to allow unknown fields and enhance tests for activity entities

### DIFF
--- a/packages/agents-activity/src/activity.ts
+++ b/packages/agents-activity/src/activity.ts
@@ -55,7 +55,7 @@ export const activityZodSchema = z.object({
   summary: z.string().min(1).optional(),
   suggestedActions: suggestedActionsZodSchema.optional(),
   attachments: z.array(attachmentZodSchema).optional(),
-  entities: z.array(entityZodSchema).optional(),
+  entities: z.array(entityZodSchema.passthrough()).optional(),
   channelData: z.any().optional(),
   action: z.string().min(1).optional(),
   replyToId: z.string().min(1).optional(),

--- a/packages/agents-activity/src/entity/entity.ts
+++ b/packages/agents-activity/src/entity/entity.ts
@@ -24,4 +24,4 @@ export interface Entity {
  */
 export const entityZodSchema = z.object({
   type: z.string().min(1)
-})
+}).passthrough()

--- a/packages/agents-activity/test/entity/entity.test.ts
+++ b/packages/agents-activity/test/entity/entity.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert'
 import { describe, it } from 'node:test'
-import { Entity } from '../../src'
+import { Activity, Entity } from '../../src'
 import { entityZodSchema } from '../../src/entity/entity'
 
 describe('Entity', () => {
@@ -13,6 +13,35 @@ describe('Entity', () => {
     // @ts-expect-error
     const entity: Entity = { }
     assert.strictEqual(entity.type, undefined)
+  })
+
+  it('should respect unknown fields', () => {
+    const entityObj: Entity = { type: 'type', unknownField: 'unknown' }
+    const entity = entityZodSchema.passthrough().parse(entityObj)
+    assert.deepEqual(entityObj, entity)
+  })
+
+  it('should respect unknown fields from activity', () => {
+    const activityObj = {
+      type: 'message',
+      entities: [{
+        type: 'mention',
+        mentioned: {
+          id: '123',
+          name: 'John Doe'
+        },
+        text: 'Hello @John Doe',
+      },
+      {
+        type: 'clientInfo',
+        country: 'US',
+        locale: 'en-US',
+        platform: 'web',
+        timezone: 'PST',
+      }]
+    }
+    const activity = Activity.fromObject(activityObj)
+    assert.deepEqual(activityObj.entities, activity.entities)
   })
 })
 


### PR DESCRIPTION
fixes #259

This pull request introduces changes to enhance the flexibility of schema validation for `Entity` and `Activity` objects by allowing unknown fields to pass through. Additionally, new test cases are added to ensure the correctness of these updates.

### Schema Validation Updates:
* [`packages/agents-activity/src/activity.ts`](diffhunk://#diff-1520d81a3e111c1eaa5cba3e1debfb5232bf126d6326d062bcf479e5062fe5a1L58-R58): Updated the `entities` field in `activityZodSchema` to use `.passthrough()`, enabling unknown fields in `Entity` objects to be preserved during validation.
* [`packages/agents-activity/src/entity/entity.ts`](diffhunk://#diff-66091caa2be6f243d9208d3353a5113a75b0a872125799ac464d948475b3eb9eL27-R27): Modified `entityZodSchema` to include `.passthrough()`, allowing unknown fields in `Entity` objects to pass through validation.

### Test Enhancements:
* `packages/agents-activity/test/entity/entity.test.ts`: 
  - Added a test to verify that unknown fields in `Entity` objects are preserved during validation.
  - Added a test to ensure that unknown fields in `Entity` objects within the `entities` array of an `Activity` object are preserved during deserialization.
  - Updated imports to include `Activity` for the new test cases.