### PR TITLE
test: add roundtrip tests for Activity value serialization

### DIFF
--- a/packages/agents-activity/test/activity/activity.value.test.ts
+++ b/packages/agents-activity/test/activity/activity.value.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert'
 import { describe, it } from 'node:test'
 import { Activity } from '../../src'
 
-describe('vale any roundtrip', () => {
+describe('value any roundtrip', () => {
   it('should roundtrip a json string', () => {
     const jsonWithString = { type: 'type', value: '{"a": "b"}' }
     const act = Activity.fromObject(jsonWithString)

--- a/packages/agents-activity/test/activity/activity.value.test.ts
+++ b/packages/agents-activity/test/activity/activity.value.test.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from 'assert'
+import { describe, it } from 'node:test'
+import { Activity } from '../../src'
+
+describe('vale any roundtrip', () => {
+  it('should roundtrip a json string', () => {
+    const jsonWithString = { type: 'type', value: '{"a": "b"}' }
+    const act = Activity.fromObject(jsonWithString)
+    assert.strictEqual(act.value, '{"a": "b"}')
+    const parsedValue = JSON.parse(act.value)
+    assert.strictEqual(parsedValue.a, 'b')
+  })
+
+  it('should roundtrip an object', () => {
+    const jsonWithString = { type: 'type', value: { a: 'b' } }
+    const act = Activity.fromObject(jsonWithString)
+    assert.deepEqual(act.value, { a: 'b' })
+    assert.strictEqual(act.value.a, 'b')
+  })
+})


### PR DESCRIPTION
This pull request adds new unit tests to ensure the proper functionality of the `Activity` class when handling JSON strings and objects. These tests verify that the `value` property correctly preserves its data during serialization and deserialization.

### Added Unit Tests:
* `packages/agents-activity/test/activity/activity.value.test.ts`:  
  - Added a test to confirm that a JSON string round-trips correctly through the `Activity.fromObject` method.  
  - Added a test to confirm that an object round-trips correctly through the `Activity.fromObject` method.