### PR TITLE
Fix issue #78: jwtMiddleware throws at startup

### DIFF
--- a/packages/agents-hosting/src/auth/jwt-middleware.ts
+++ b/packages/agents-hosting/src/auth/jwt-middleware.ts
@@ -60,6 +60,9 @@ const verifyToken = async (raw: string, config: AuthConfiguration): Promise<JwtP
 
       resolve(tokenClaims)
     })
+  }).catch((err) => {
+    logger.error('Error in verifyToken: ', err)
+    throw err
   })
 }
 


### PR DESCRIPTION
Add error handling in `verifyToken` function in `jwt-middleware.ts` to catch and log errors from `ServerResponse.setHeader`.

* Catch and log errors in `verifyToken` function
* Throw the caught error to propagate it further

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/Agents-for-js/pull/315?shareId=891d0d9f-9319-446a-a522-7ec5ea9ac227).