### PR TITLE
chore: update dependencies and fix typo in streaming response message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       ],
       "devDependencies": {
         "@microsoft/microsoft-graph-types": "^2.40.0",
-        "@microsoft/teams-app-test-tool": "^0.2.10",
+        "@microsoft/teams-app-test-tool": "^0.2.14",
         "@types/debug": "^4.1.12",
         "@types/express": "^5.0.3",
         "@types/express-serve-static-core": "^5.0.5",
@@ -24,7 +24,7 @@
         "esbuild": "^0.25.4",
         "eslint": "^9.28.0",
         "global": "4.4.0",
-        "neostandard": "^0.12.1",
+        "neostandard": "^0.12.2",
         "nerdbank-gitversioning": "^3.7.115",
         "npm-run-all": "^4.1.5",
         "sinon": "^21.0.0",
@@ -297,17 +297,17 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.4.3",
+      "version": "1.4.4",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.0.2",
+        "@emnapi/wasi-threads": "1.0.3",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.4.3",
+      "version": "1.4.4",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -316,7 +316,7 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -325,7 +325,7 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "ppc64"
       ],
@@ -340,7 +340,7 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "arm"
       ],
@@ -355,7 +355,7 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "arm64"
       ],
@@ -370,7 +370,7 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "x64"
       ],
@@ -385,7 +385,7 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "arm64"
       ],
@@ -400,7 +400,7 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "x64"
       ],
@@ -415,7 +415,7 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "arm64"
       ],
@@ -430,7 +430,7 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "x64"
       ],
@@ -445,7 +445,7 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "arm"
       ],
@@ -460,7 +460,7 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "arm64"
       ],
@@ -475,7 +475,7 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "ia32"
       ],
@@ -490,7 +490,7 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "loong64"
       ],
@@ -505,7 +505,7 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "mips64el"
       ],
@@ -520,7 +520,7 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "ppc64"
       ],
@@ -535,7 +535,7 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "riscv64"
       ],
@@ -550,7 +550,7 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "s390x"
       ],
@@ -565,7 +565,7 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "x64"
       ],
@@ -580,7 +580,7 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "arm64"
       ],
@@ -595,7 +595,7 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "x64"
       ],
@@ -610,7 +610,7 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "arm64"
       ],
@@ -625,7 +625,7 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "x64"
       ],
@@ -639,8 +639,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.6",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "x64"
       ],
@@ -655,7 +670,7 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "arm64"
       ],
@@ -670,7 +685,7 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "ia32"
       ],
@@ -685,7 +700,7 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "cpu": [
         "x64"
       ],
@@ -1083,7 +1098,7 @@
       }
     },
     "node_modules/@microsoft/teams-app-test-tool": {
-      "version": "0.2.13",
+      "version": "0.2.14",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
@@ -1403,15 +1418,15 @@
       "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.35.1",
+      "version": "8.36.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.35.1",
-        "@typescript-eslint/type-utils": "8.35.1",
-        "@typescript-eslint/utils": "8.35.1",
-        "@typescript-eslint/visitor-keys": "8.35.1",
+        "@typescript-eslint/scope-manager": "8.36.0",
+        "@typescript-eslint/type-utils": "8.36.0",
+        "@typescript-eslint/utils": "8.36.0",
+        "@typescript-eslint/visitor-keys": "8.36.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -1425,7 +1440,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.35.1",
+        "@typescript-eslint/parser": "^8.36.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
@@ -1439,14 +1454,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.35.1",
+      "version": "8.36.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.35.1",
-        "@typescript-eslint/types": "8.35.1",
-        "@typescript-eslint/typescript-estree": "8.35.1",
-        "@typescript-eslint/visitor-keys": "8.35.1",
+        "@typescript-eslint/scope-manager": "8.36.0",
+        "@typescript-eslint/types": "8.36.0",
+        "@typescript-eslint/typescript-estree": "8.36.0",
+        "@typescript-eslint/visitor-keys": "8.36.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1462,12 +1477,12 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.35.1",
+      "version": "8.36.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.35.1",
-        "@typescript-eslint/types": "^8.35.1",
+        "@typescript-eslint/tsconfig-utils": "^8.36.0",
+        "@typescript-eslint/types": "^8.36.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1482,12 +1497,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.35.1",
+      "version": "8.36.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.35.1",
-        "@typescript-eslint/visitor-keys": "8.35.1"
+        "@typescript-eslint/types": "8.36.0",
+        "@typescript-eslint/visitor-keys": "8.36.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1498,7 +1513,7 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.35.1",
+      "version": "8.36.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1513,12 +1528,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.35.1",
+      "version": "8.36.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.35.1",
-        "@typescript-eslint/utils": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.36.0",
+        "@typescript-eslint/utils": "8.36.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -1535,7 +1550,7 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.35.1",
+      "version": "8.36.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1547,14 +1562,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.35.1",
+      "version": "8.36.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.35.1",
-        "@typescript-eslint/tsconfig-utils": "8.35.1",
-        "@typescript-eslint/types": "8.35.1",
-        "@typescript-eslint/visitor-keys": "8.35.1",
+        "@typescript-eslint/project-service": "8.36.0",
+        "@typescript-eslint/tsconfig-utils": "8.36.0",
+        "@typescript-eslint/types": "8.36.0",
+        "@typescript-eslint/visitor-keys": "8.36.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1596,14 +1611,14 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.35.1",
+      "version": "8.36.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.35.1",
-        "@typescript-eslint/types": "8.35.1",
-        "@typescript-eslint/typescript-estree": "8.35.1"
+        "@typescript-eslint/scope-manager": "8.36.0",
+        "@typescript-eslint/types": "8.36.0",
+        "@typescript-eslint/typescript-estree": "8.36.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1618,11 +1633,11 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.35.1",
+      "version": "8.36.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/types": "8.36.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -1646,7 +1661,7 @@
       }
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "arm"
       ],
@@ -1658,7 +1673,7 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "arm64"
       ],
@@ -1670,7 +1685,7 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "arm64"
       ],
@@ -1682,7 +1697,7 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "x64"
       ],
@@ -1694,7 +1709,7 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "x64"
       ],
@@ -1706,7 +1721,7 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "arm"
       ],
@@ -1718,7 +1733,7 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "arm"
       ],
@@ -1730,7 +1745,7 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "arm64"
       ],
@@ -1742,7 +1757,7 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "arm64"
       ],
@@ -1754,7 +1769,7 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "ppc64"
       ],
@@ -1766,7 +1781,7 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "riscv64"
       ],
@@ -1778,7 +1793,7 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "riscv64"
       ],
@@ -1790,7 +1805,7 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "s390x"
       ],
@@ -1802,7 +1817,7 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "x64"
       ],
@@ -1814,7 +1829,7 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "x64"
       ],
@@ -1826,7 +1841,7 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "wasm32"
       ],
@@ -1841,7 +1856,7 @@
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "arm64"
       ],
@@ -1853,7 +1868,7 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "ia32"
       ],
@@ -1865,7 +1880,7 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "cpu": [
         "x64"
       ],
@@ -1987,7 +2002,7 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.3",
+      "version": "7.1.4",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -2856,7 +2871,7 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.5",
+      "version": "0.25.6",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2867,31 +2882,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.5",
-        "@esbuild/android-arm": "0.25.5",
-        "@esbuild/android-arm64": "0.25.5",
-        "@esbuild/android-x64": "0.25.5",
-        "@esbuild/darwin-arm64": "0.25.5",
-        "@esbuild/darwin-x64": "0.25.5",
-        "@esbuild/freebsd-arm64": "0.25.5",
-        "@esbuild/freebsd-x64": "0.25.5",
-        "@esbuild/linux-arm": "0.25.5",
-        "@esbuild/linux-arm64": "0.25.5",
-        "@esbuild/linux-ia32": "0.25.5",
-        "@esbuild/linux-loong64": "0.25.5",
-        "@esbuild/linux-mips64el": "0.25.5",
-        "@esbuild/linux-ppc64": "0.25.5",
-        "@esbuild/linux-riscv64": "0.25.5",
-        "@esbuild/linux-s390x": "0.25.5",
-        "@esbuild/linux-x64": "0.25.5",
-        "@esbuild/netbsd-arm64": "0.25.5",
-        "@esbuild/netbsd-x64": "0.25.5",
-        "@esbuild/openbsd-arm64": "0.25.5",
-        "@esbuild/openbsd-x64": "0.25.5",
-        "@esbuild/sunos-x64": "0.25.5",
-        "@esbuild/win32-arm64": "0.25.5",
-        "@esbuild/win32-ia32": "0.25.5",
-        "@esbuild/win32-x64": "0.25.5"
+        "@esbuild/aix-ppc64": "0.25.6",
+        "@esbuild/android-arm": "0.25.6",
+        "@esbuild/android-arm64": "0.25.6",
+        "@esbuild/android-x64": "0.25.6",
+        "@esbuild/darwin-arm64": "0.25.6",
+        "@esbuild/darwin-x64": "0.25.6",
+        "@esbuild/freebsd-arm64": "0.25.6",
+        "@esbuild/freebsd-x64": "0.25.6",
+        "@esbuild/linux-arm": "0.25.6",
+        "@esbuild/linux-arm64": "0.25.6",
+        "@esbuild/linux-ia32": "0.25.6",
+        "@esbuild/linux-loong64": "0.25.6",
+        "@esbuild/linux-mips64el": "0.25.6",
+        "@esbuild/linux-ppc64": "0.25.6",
+        "@esbuild/linux-riscv64": "0.25.6",
+        "@esbuild/linux-s390x": "0.25.6",
+        "@esbuild/linux-x64": "0.25.6",
+        "@esbuild/netbsd-arm64": "0.25.6",
+        "@esbuild/netbsd-x64": "0.25.6",
+        "@esbuild/openbsd-arm64": "0.25.6",
+        "@esbuild/openbsd-x64": "0.25.6",
+        "@esbuild/openharmony-arm64": "0.25.6",
+        "@esbuild/sunos-x64": "0.25.6",
+        "@esbuild/win32-arm64": "0.25.6",
+        "@esbuild/win32-ia32": "0.25.6",
+        "@esbuild/win32-x64": "0.25.6"
       }
     },
     "node_modules/escape-html": {
@@ -3108,12 +3124,11 @@
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "17.20.0",
+      "version": "17.21.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.5.0",
-        "@typescript-eslint/utils": "^8.26.1",
         "enhanced-resolve": "^5.17.1",
         "eslint-plugin-es-x": "^7.8.0",
         "get-tsconfig": "^4.8.1",
@@ -4820,21 +4835,21 @@
       }
     },
     "node_modules/neostandard": {
-      "version": "0.12.1",
+      "version": "0.12.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "@stylistic/eslint-plugin": "2.11.0",
-        "eslint-import-resolver-typescript": "^3.7.0",
-        "eslint-plugin-import-x": "^4.5.0",
-        "eslint-plugin-n": "^17.14.0",
+        "eslint-import-resolver-typescript": "^3.10.1",
+        "eslint-plugin-import-x": "^4.16.1",
+        "eslint-plugin-n": "^17.20.0",
         "eslint-plugin-promise": "^7.2.1",
-        "eslint-plugin-react": "^7.37.2",
+        "eslint-plugin-react": "^7.37.5",
         "find-up": "^5.0.0",
-        "globals": "^15.13.0",
+        "globals": "^15.15.0",
         "peowly": "^1.3.2",
-        "typescript-eslint": "^8.17.0"
+        "typescript-eslint": "^8.35.1"
       },
       "bin": {
         "neostandard": "cli.mjs"
@@ -6400,13 +6415,13 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.35.1",
+      "version": "8.36.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.35.1",
-        "@typescript-eslint/parser": "8.35.1",
-        "@typescript-eslint/utils": "8.35.1"
+        "@typescript-eslint/eslint-plugin": "8.36.0",
+        "@typescript-eslint/parser": "8.36.0",
+        "@typescript-eslint/utils": "8.36.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6454,7 +6469,7 @@
       }
     },
     "node_modules/unrs-resolver": {
-      "version": "1.10.1",
+      "version": "1.11.0",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -6465,25 +6480,25 @@
         "url": "https://opencollective.com/unrs-resolver"
       },
       "optionalDependencies": {
-        "@unrs/resolver-binding-android-arm-eabi": "1.10.1",
-        "@unrs/resolver-binding-android-arm64": "1.10.1",
-        "@unrs/resolver-binding-darwin-arm64": "1.10.1",
-        "@unrs/resolver-binding-darwin-x64": "1.10.1",
-        "@unrs/resolver-binding-freebsd-x64": "1.10.1",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.10.1",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.10.1",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.10.1",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.10.1",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.10.1",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.10.1",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.10.1",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.10.1",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.10.1",
-        "@unrs/resolver-binding-linux-x64-musl": "1.10.1",
-        "@unrs/resolver-binding-wasm32-wasi": "1.10.1",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.10.1",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.10.1",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.10.1"
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.0",
+        "@unrs/resolver-binding-android-arm64": "1.11.0",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.0",
+        "@unrs/resolver-binding-darwin-x64": "1.11.0",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.0",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.0",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.0",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.0",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.0",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.0",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.0",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.0",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.0",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.0",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.0",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.0",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.0",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.0",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.0"
       }
     },
     "node_modules/uri-js": {
@@ -6668,7 +6683,7 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.67",
+      "version": "3.25.75",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -6680,7 +6695,7 @@
       "license": "MIT",
       "dependencies": {
         "uuid": "^11.1.0",
-        "zod": "3.25.67"
+        "zod": "3.25.75"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "devDependencies": {
     "@microsoft/microsoft-graph-types": "^2.40.0",
-    "@microsoft/teams-app-test-tool": "^0.2.10",
+    "@microsoft/teams-app-test-tool": "^0.2.14",
     "@types/debug": "^4.1.12",
     "@types/express": "^5.0.3",
     "@types/express-serve-static-core": "^5.0.5",
@@ -46,7 +46,7 @@
     "esbuild": "^0.25.4",
     "eslint": "^9.28.0",
     "global": "4.4.0",
-    "neostandard": "^0.12.1",
+    "neostandard": "^0.12.2",
     "nerdbank-gitversioning": "^3.7.115",
     "npm-run-all": "^4.1.5",
     "sinon": "^21.0.0",

--- a/packages/agents-activity/package.json
+++ b/packages/agents-activity/package.json
@@ -20,7 +20,7 @@
   "types": "dist/src/index.d.ts",
   "dependencies": {
     "uuid": "^11.1.0",
-    "zod": "3.25.67"
+    "zod": "3.25.75"
   },
   "license": "MIT",
   "files": [

--- a/packages/agents-hosting/src/app/streaming/streamingResponse.ts
+++ b/packages/agents-hosting/src/app/streaming/streamingResponse.ts
@@ -240,7 +240,7 @@ export class StreamingResponse {
         // Send final message
         return Activity.fromObject({
           type: 'message',
-          text: this._message || 'end strean response',
+          text: this._message || 'end of stream response',
           attachments: this._attachments,
           channelData: {
             streamType: 'final',


### PR DESCRIPTION
This pull request includes updates to dependencies across multiple `package.json` files and a minor text correction in the `StreamingResponse` class.

### Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L39-R39): Updated `@microsoft/teams-app-test-tool` from `^0.2.10` to `^0.2.14` and `neostandard` from `^0.12.1` to `^0.12.2`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L39-R39) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L49-R49)
* [`packages/agents-activity/package.json`](diffhunk://#diff-4f86354aaeecf8073a43fba31cdd64ee1f1b619ed5d99459609fb3c4b0555185L23-R23): Updated `zod` from `3.25.67` to `3.25.75`.

### Text Correction:
* [`packages/agents-hosting/src/app/streaming/streamingResponse.ts`](diffhunk://#diff-0bf8103fcdb8949e7319c9d73139fdfdeef60a495036065f043843ded3c8c9b0L243-R243): Fixed a typo in the `StreamingResponse` class, changing "end strean response" to "end of stream response".