### PR TITLE
Support multiple connections

### DIFF
--- a/packages/agents-hosting/src/app/authorization.ts
+++ b/packages/agents-hosting/src/app/authorization.ts
@@ -8,7 +8,7 @@ import { debug } from '../logger'
 import { TurnState } from './turnState'
 import { Storage } from '../storage'
 import { OAuthFlow, TokenResponse } from '../oauth'
-import { AuthConfiguration, MsalTokenProvider } from '../auth'
+import { AuthConfiguration, loadAuthConfigFromEnv, MsalTokenProvider } from '../auth'
 import jwt, { JwtPayload } from 'jsonwebtoken'
 import { Activity } from '@microsoft/agents-activity'
 
@@ -40,6 +40,8 @@ export interface AuthHandler {
   title?: string,
   /** Text to display on auth cards/UI. */
   text?: string,
+
+  cnxPrefix?: string
 }
 
 /**
@@ -206,7 +208,7 @@ export class Authorization {
     const authHandler = this.getAuthHandlerOrThrow(authHandlerId)
     const tokenResponse = await authHandler.flow?.getUserToken(context)!
     if (this.isExchangeable(tokenResponse.token)) {
-      return await this.handleObo(context, tokenResponse.token!, scopes)
+      return await this.handleObo(context, tokenResponse.token!, scopes, authHandler.cnxPrefix)
     }
     return tokenResponse
   }
@@ -235,9 +237,12 @@ export class Authorization {
    * @returns A promise that resolves to the exchanged token response.
    * @private
    */
-  private async handleObo (context: TurnContext, token: string, scopes: string[]): Promise<TokenResponse> {
+  private async handleObo (context: TurnContext, token: string, scopes: string[], cnxPrefix?: string): Promise<TokenResponse> {
     const msalTokenProvider = new MsalTokenProvider()
-    const authConfig: AuthConfiguration = context.adapter.authConfig
+    let authConfig: AuthConfiguration = context.adapter.authConfig
+    if (cnxPrefix) {
+      authConfig = loadAuthConfigFromEnv(cnxPrefix)
+    }
     const newToken = await msalTokenProvider.acquireTokenOnBehalfOf(authConfig, scopes, token)
     return { token: newToken }
   }

--- a/packages/agents-hosting/src/app/authorization.ts
+++ b/packages/agents-hosting/src/app/authorization.ts
@@ -132,6 +132,7 @@ export class Authorization {
       currentAuthHandler.name = currentAuthHandler.name ?? process.env[ah + '_connectionName'] as string
       currentAuthHandler.title = currentAuthHandler.title ?? process.env[ah + '_connectionTitle'] as string
       currentAuthHandler.text = currentAuthHandler.text ?? process.env[ah + '_connectionText'] as string
+      currentAuthHandler.cnxPrefix = currentAuthHandler.cnxPrefix ?? process.env[ah + '_cnxPrefix'] as string
       currentAuthHandler.flow = new OAuthFlow(this.storage, currentAuthHandler.name, null!, currentAuthHandler.title, currentAuthHandler.text)
     }
     logger.info('Authorization handlers configured with', Object.keys(this.authHandlers).length, 'handlers')

--- a/packages/agents-hosting/src/app/authorization.ts
+++ b/packages/agents-hosting/src/app/authorization.ts
@@ -237,7 +237,7 @@ export class Authorization {
    */
   private async handleObo (context: TurnContext, token: string, scopes: string[]): Promise<TokenResponse> {
     const msalTokenProvider = new MsalTokenProvider()
-    const authConfig: AuthConfiguration = context.adapter.authConfig!
+    const authConfig: AuthConfiguration = context.adapter.authConfig
     const newToken = await msalTokenProvider.acquireTokenOnBehalfOf(authConfig, scopes, token)
     return { token: newToken }
   }

--- a/packages/agents-hosting/src/app/authorization.ts
+++ b/packages/agents-hosting/src/app/authorization.ts
@@ -237,7 +237,7 @@ export class Authorization {
    */
   private async handleObo (context: TurnContext, token: string, scopes: string[]): Promise<TokenResponse> {
     const msalTokenProvider = new MsalTokenProvider()
-    const authConfig: AuthConfiguration = context.adapter.authConfig
+    const authConfig: AuthConfiguration = context.adapter.authConfig!
     const newToken = await msalTokenProvider.acquireTokenOnBehalfOf(authConfig, scopes, token)
     return { token: newToken }
   }

--- a/packages/agents-hosting/src/app/authorization.ts
+++ b/packages/agents-hosting/src/app/authorization.ts
@@ -205,7 +205,7 @@ export class Authorization {
    * ```
    */
   public async exchangeToken (context: TurnContext, scopes: string[], authHandlerId: string): Promise<TokenResponse> {
-    logger.info('getToken from user token service for authHandlerId:', authHandlerId)
+    logger.info('exchangeToken from user token service for authHandlerId:', authHandlerId)
     const authHandler = this.getAuthHandlerOrThrow(authHandlerId)
     const tokenResponse = await authHandler.flow?.getUserToken(context)!
     if (this.isExchangeable(tokenResponse.token)) {

--- a/packages/agents-hosting/src/auth/authConfiguration.ts
+++ b/packages/agents-hosting/src/auth/authConfiguration.ts
@@ -15,7 +15,7 @@ export interface AuthConfiguration {
   /**
    * The client ID for the authentication configuration. Required in production.
    */
-  clientId?: string
+  clientId: string
 
   /**
    * The client secret for the authentication configuration.
@@ -74,7 +74,7 @@ export const loadAuthConfigFromEnv: (cnxName?: string) => AuthConfiguration = (c
     }
     return {
       tenantId: process.env.tenantId,
-      clientId: process.env.clientId,
+      clientId: process.env.clientId!,
       clientSecret: process.env.clientSecret,
       certPemFile: process.env.certPemFile,
       certKeyFile: process.env.certKeyFile,
@@ -87,12 +87,9 @@ export const loadAuthConfigFromEnv: (cnxName?: string) => AuthConfiguration = (c
       ]
     }
   } else {
-    if (process.env[`${cnxName}_clientId`] === undefined && process.env.NODE_ENV === 'production') {
-      throw new Error('ClientId required in production, for connection: ' + cnxName)
-    }
     return {
       tenantId: process.env[`${cnxName}_tenantId`],
-      clientId: process.env[`${cnxName}_clientId`],
+      clientId: process.env[`${cnxName}_clientId`] ?? (() => { throw new Error(`ClientId not found for connection: ${cnxName}`) })(),
       clientSecret: process.env[`${cnxName}_clientSecret`],
       certPemFile: process.env[`${cnxName}_certPemFile`],
       certKeyFile: process.env[`${cnxName}_certKeyFile`],
@@ -123,7 +120,7 @@ export const loadPrevAuthConfigFromEnv: () => AuthConfiguration = () => {
   }
   return {
     tenantId: process.env.MicrosoftAppTenantId,
-    clientId: process.env.MicrosoftAppId,
+    clientId: process.env.MicrosoftAppId!,
     clientSecret: process.env.MicrosoftAppPassword,
     certPemFile: process.env.certPemFile,
     certKeyFile: process.env.certKeyFile,

--- a/packages/agents-hosting/src/auth/authConfiguration.ts
+++ b/packages/agents-hosting/src/auth/authConfiguration.ts
@@ -67,23 +67,43 @@ export interface AuthConfiguration {
  * @returns The authentication configuration.
  * @throws Will throw an error if clientId is not provided in production.
  */
-export const loadAuthConfigFromEnv: () => AuthConfiguration = () => {
-  if (process.env.clientId === undefined && process.env.NODE_ENV === 'production') {
-    throw new Error('ClientId required in production')
-  }
-  return {
-    tenantId: process.env.tenantId,
-    clientId: process.env.clientId,
-    clientSecret: process.env.clientSecret,
-    certPemFile: process.env.certPemFile,
-    certKeyFile: process.env.certKeyFile,
-    connectionName: process.env.connectionName,
-    FICClientId: process.env.FICClientId,
-    issuers: [
-      'https://api.botframework.com',
-      `https://sts.windows.net/${process.env.tenantId}/`,
-      `https://login.microsoftonline.com/${process.env.tenantId}/v2.0`
-    ]
+export const loadAuthConfigFromEnv: (cnxName?: string) => AuthConfiguration = (cnxName?: string) => {
+  if (cnxName === undefined) {
+    if (process.env.clientId === undefined && process.env.NODE_ENV === 'production') {
+      throw new Error('ClientId required in production')
+    }
+    return {
+      tenantId: process.env.tenantId,
+      clientId: process.env.clientId,
+      clientSecret: process.env.clientSecret,
+      certPemFile: process.env.certPemFile,
+      certKeyFile: process.env.certKeyFile,
+      connectionName: process.env.connectionName,
+      FICClientId: process.env.FICClientId,
+      issuers: [
+        'https://api.botframework.com',
+        `https://sts.windows.net/${process.env.tenantId}/`,
+        `https://login.microsoftonline.com/${process.env.tenantId}/v2.0`
+      ]
+    }
+  } else {
+    if (process.env[`${cnxName}_clientId`] === undefined && process.env.NODE_ENV === 'production') {
+      throw new Error('ClientId required in production, for connection: ' + cnxName)
+    }
+    return {
+      tenantId: process.env[`${cnxName}_tenantId`],
+      clientId: process.env[`${cnxName}_clientId`],
+      clientSecret: process.env[`${cnxName}_clientSecret`],
+      certPemFile: process.env[`${cnxName}_certPemFile`],
+      certKeyFile: process.env[`${cnxName}_certKeyFile`],
+      connectionName: process.env[`${cnxName}_connectionName`],
+      FICClientId: process.env.FICClientId,
+      issuers: [
+        'https://api.botframework.com',
+        `https://sts.windows.net/${process.env[`${cnxName}_tenantId`]}/`,
+        `https://login.microsoftonline.com/${process.env[`${cnxName}_tenantId`]}/v2.0`
+      ]
+    }
   }
 }
 

--- a/packages/agents-hosting/src/baseAdapter.ts
+++ b/packages/agents-hosting/src/baseAdapter.ts
@@ -53,7 +53,7 @@ export abstract class BaseAdapter {
   /**
    * The authentication configuration for the adapter.
    */
-  authConfig: AuthConfiguration | null = null
+  abstract authConfig: AuthConfiguration // | null = null
 
   /**
    * Sends a set of activities to the conversation.

--- a/packages/agents-hosting/src/baseAdapter.ts
+++ b/packages/agents-hosting/src/baseAdapter.ts
@@ -53,7 +53,7 @@ export abstract class BaseAdapter {
   /**
    * The authentication configuration for the adapter.
    */
-  authConfig: AuthConfiguration = { issuers: [] }
+  authConfig: AuthConfiguration | null = null
 
   /**
    * Sends a set of activities to the conversation.

--- a/packages/agents-hosting/src/baseAdapter.ts
+++ b/packages/agents-hosting/src/baseAdapter.ts
@@ -53,7 +53,7 @@ export abstract class BaseAdapter {
   /**
    * The authentication configuration for the adapter.
    */
-  abstract authConfig: AuthConfiguration // | null = null
+  abstract authConfig: AuthConfiguration
 
   /**
    * Sends a set of activities to the conversation.

--- a/packages/agents-hosting/src/cloudAdapter.ts
+++ b/packages/agents-hosting/src/cloudAdapter.ts
@@ -69,7 +69,7 @@ export class CloudAdapter extends BaseAdapter {
   ): Promise<ConnectorClient> {
     return ConnectorClient.createClientWithAuthAsync(
       serviceUrl,
-      this.authConfig!,
+      this.authConfig,
       this.authProvider,
       scope
     )

--- a/packages/agents-hosting/src/cloudAdapter.ts
+++ b/packages/agents-hosting/src/cloudAdapter.ts
@@ -69,7 +69,7 @@ export class CloudAdapter extends BaseAdapter {
   ): Promise<ConnectorClient> {
     return ConnectorClient.createClientWithAuthAsync(
       serviceUrl,
-      this.authConfig,
+      this.authConfig!,
       this.authProvider,
       scope
     )
@@ -98,7 +98,7 @@ export class CloudAdapter extends BaseAdapter {
   }
 
   async createTurnContextWithScope (activity: Activity, logic: AgentHandler, scope: string): Promise<TurnContext> {
-    this.connectorClient = await ConnectorClient.createClientWithAuthAsync(activity.serviceUrl!, this.authConfig, this.authProvider, scope)
+    this.connectorClient = await ConnectorClient.createClientWithAuthAsync(activity.serviceUrl!, this.authConfig!, this.authProvider, scope)
     return new TurnContext(this, activity)
   }
 

--- a/packages/agents-hosting/src/cloudAdapter.ts
+++ b/packages/agents-hosting/src/cloudAdapter.ts
@@ -37,7 +37,7 @@ export class CloudAdapter extends BaseAdapter {
    * Client for connecting to the Bot Framework Connector service
    */
   public connectorClient!: ConnectorClient
-
+  authConfig: AuthConfiguration
   /**
    * Creates an instance of CloudAdapter.
    * @param authConfig - The authentication configuration for securing communications

--- a/packages/agents-hosting/src/oauth/oAuthFlow.ts
+++ b/packages/agents-hosting/src/oauth/oAuthFlow.ts
@@ -335,7 +335,7 @@ export class OAuthFlow {
   private async initializeTokenClient (context: TurnContext) {
     if (this.userTokenClient === undefined || this.userTokenClient === null) {
       const scope = 'https://api.botframework.com'
-      const accessToken = await context.adapter.authProvider.getAccessToken(context.adapter.authConfig!, scope)
+      const accessToken = await context.adapter.authProvider.getAccessToken(context.adapter.authConfig, scope)
       this.userTokenClient = new UserTokenClient(accessToken, context.adapter.authConfig!.clientId!)
     }
   }

--- a/packages/agents-hosting/src/oauth/oAuthFlow.ts
+++ b/packages/agents-hosting/src/oauth/oAuthFlow.ts
@@ -335,8 +335,8 @@ export class OAuthFlow {
   private async initializeTokenClient (context: TurnContext) {
     if (this.userTokenClient === undefined || this.userTokenClient === null) {
       const scope = 'https://api.botframework.com'
-      const accessToken = await context.adapter.authProvider.getAccessToken(context.adapter.authConfig, scope)
-      this.userTokenClient = new UserTokenClient(accessToken, context.adapter.authConfig.clientId!)
+      const accessToken = await context.adapter.authProvider.getAccessToken(context.adapter.authConfig!, scope)
+      this.userTokenClient = new UserTokenClient(accessToken, context.adapter.authConfig!.clientId!)
     }
   }
 

--- a/packages/agents-hosting/src/oauth/userTokenClient.ts
+++ b/packages/agents-hosting/src/oauth/userTokenClient.ts
@@ -117,6 +117,9 @@ export class UserTokenClient {
       return response.data as TokenResponse
     } catch (error: any) {
       logger.error(error)
+      if (error.response?.data) {
+        logger.error(error.response.data)
+      }
       return { token: undefined }
     }
   }

--- a/packages/agents-hosting/test/hosting/adapter/turnContext.test.ts
+++ b/packages/agents-hosting/test/hosting/adapter/turnContext.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert'
 import { describe, it } from 'node:test'
-import { AttachmentData, AttachmentInfo, MessageFactory, ResourceResponse, TurnContext } from '../../../src'
+import { AttachmentData, AttachmentInfo, AuthConfiguration, MessageFactory, ResourceResponse, TurnContext } from '../../../src'
 import { Activity, ActivityTypes, ConversationReference, DeliveryModes } from '@microsoft/agents-activity'
 import { BaseAdapter } from '../../../src/baseAdapter'
 
@@ -29,6 +29,15 @@ const testTraceMessage: Activity = Activity.fromObject(
 )
 
 class SimpleAdapter extends BaseAdapter {
+  authConfig: AuthConfiguration
+  constructor () {
+    super()
+    this.authConfig = {
+      clientId: 'test-client-id',
+      issuers: []
+    }
+  }
+
   getAttachmentInfo (attachmentId: string): Promise<AttachmentInfo> {
     throw new Error('Method not implemented.')
   }

--- a/packages/agents-hosting/test/hosting/authConfiguration.test.ts
+++ b/packages/agents-hosting/test/hosting/authConfiguration.test.ts
@@ -1,0 +1,221 @@
+import { strict as assert } from 'assert'
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import { AuthConfiguration, loadAuthConfigFromEnv, loadPrevAuthConfigFromEnv } from '../../src'
+
+describe('AuthConfiguration', () => {
+  let originalEnv: NodeJS.ProcessEnv
+
+  beforeEach(() => {
+    // Store original environment variables
+    originalEnv = { ...process.env }
+
+    // Reset environment variables before each test
+    process.env.tenantId = 'test-tenant-id'
+    process.env.clientId = 'test-client-id'
+    process.env.clientSecret = 'test-client-secret'
+    process.env.certPemFile = 'test-cert.pem'
+    process.env.certKeyFile = 'test-cert.key'
+    process.env.connectionName = 'test-connection'
+    process.env.FICClientId = 'test-fic-client-id'
+    process.env.NODE_ENV = 'development'
+  })
+
+  afterEach(() => {
+    // Restore original environment variables
+    process.env = originalEnv
+  })
+
+  describe('loadAuthConfigFromEnv without connection name', () => {
+    it('should load configuration from environment variables', () => {
+      const config: AuthConfiguration = loadAuthConfigFromEnv()
+      assert.strictEqual(config.tenantId, 'test-tenant-id')
+      assert.strictEqual(config.clientId, 'test-client-id')
+      assert.strictEqual(config.clientSecret, 'test-client-secret')
+      assert.strictEqual(config.certPemFile, 'test-cert.pem')
+      assert.strictEqual(config.certKeyFile, 'test-cert.key')
+      assert.strictEqual(config.connectionName, 'test-connection')
+      assert.strictEqual(config.FICClientId, 'test-fic-client-id')
+      assert.deepStrictEqual(config.issuers, [
+        'https://api.botframework.com',
+        'https://sts.windows.net/test-tenant-id/',
+        'https://login.microsoftonline.com/test-tenant-id/v2.0'
+      ])
+    })
+
+    it('should throw an error if clientId is not provided in production', () => {
+      process.env.NODE_ENV = 'production'
+      delete process.env.clientId
+      assert.throws(() => loadAuthConfigFromEnv(), /ClientId required in production/)
+    })
+
+    it('should allow missing clientId in development environment', () => {
+      process.env.NODE_ENV = 'development'
+      delete process.env.clientId
+      const config = loadAuthConfigFromEnv()
+      assert.strictEqual(config.clientId, undefined)
+    })
+
+    it('should handle missing optional environment variables', () => {
+      delete process.env.tenantId
+      delete process.env.clientSecret
+      delete process.env.certPemFile
+      delete process.env.certKeyFile
+      delete process.env.connectionName
+      delete process.env.FICClientId
+
+      const config = loadAuthConfigFromEnv()
+      assert.strictEqual(config.tenantId, undefined)
+      assert.strictEqual(config.clientSecret, undefined)
+      assert.strictEqual(config.certPemFile, undefined)
+      assert.strictEqual(config.certKeyFile, undefined)
+      assert.strictEqual(config.connectionName, undefined)
+      assert.strictEqual(config.FICClientId, undefined)
+      assert.deepStrictEqual(config.issuers, [
+        'https://api.botframework.com',
+        'https://sts.windows.net/undefined/',
+        'https://login.microsoftonline.com/undefined/v2.0'
+      ])
+    })
+  })
+
+  describe('loadAuthConfigFromEnv with connection name', () => {
+    beforeEach(() => {
+      // Set up connection-specific environment variables
+      process.env.myconn_tenantId = 'conn-tenant-id'
+      process.env.myconn_clientId = 'conn-client-id'
+      process.env.myconn_clientSecret = 'conn-client-secret'
+      process.env.myconn_certPemFile = 'conn-cert.pem'
+      process.env.myconn_certKeyFile = 'conn-cert.key'
+      process.env.myconn_connectionName = 'conn-connection-name'
+    })
+
+    it('should load configuration from connection-specific environment variables', () => {
+      const config = loadAuthConfigFromEnv('myconn')
+      assert.strictEqual(config.tenantId, 'conn-tenant-id')
+      assert.strictEqual(config.clientId, 'conn-client-id')
+      assert.strictEqual(config.clientSecret, 'conn-client-secret')
+      assert.strictEqual(config.certPemFile, 'conn-cert.pem')
+      assert.strictEqual(config.certKeyFile, 'conn-cert.key')
+      assert.strictEqual(config.connectionName, 'conn-connection-name')
+      assert.strictEqual(config.FICClientId, 'test-fic-client-id') // Falls back to global FICClientId
+      assert.deepStrictEqual(config.issuers, [
+        'https://api.botframework.com',
+        'https://sts.windows.net/conn-tenant-id/',
+        'https://login.microsoftonline.com/conn-tenant-id/v2.0'
+      ])
+    })
+
+    it('should throw an error if connection-specific clientId is not found', () => {
+      assert.throws(() => loadAuthConfigFromEnv('nonexistent'), /ClientId not found for connection: nonexistent/)
+    })
+
+    it('should handle missing optional connection-specific environment variables', () => {
+      process.env.minimal_clientId = 'minimal-client-id'
+
+      const config = loadAuthConfigFromEnv('minimal')
+      assert.strictEqual(config.tenantId, undefined)
+      assert.strictEqual(config.clientId, 'minimal-client-id')
+      assert.strictEqual(config.clientSecret, undefined)
+      assert.strictEqual(config.certPemFile, undefined)
+      assert.strictEqual(config.certKeyFile, undefined)
+      assert.strictEqual(config.connectionName, undefined)
+      assert.strictEqual(config.FICClientId, 'test-fic-client-id')
+    })
+  })
+
+  describe('loadPrevAuthConfigFromEnv', () => {
+    beforeEach(() => {
+      // Set up Microsoft App environment variables
+      process.env.MicrosoftAppId = 'microsoft-app-id'
+      process.env.MicrosoftAppPassword = 'microsoft-app-password'
+      process.env.MicrosoftAppTenantId = 'microsoft-tenant-id'
+      process.env.MicrosoftAppClientId = 'microsoft-app-client-id'
+    })
+
+    it('should load configuration from Microsoft App environment variables', () => {
+      const config = loadPrevAuthConfigFromEnv()
+      assert.strictEqual(config.tenantId, 'microsoft-tenant-id')
+      assert.strictEqual(config.clientId, 'microsoft-app-id')
+      assert.strictEqual(config.clientSecret, 'microsoft-app-password')
+      assert.strictEqual(config.FICClientId, 'microsoft-app-client-id')
+      assert.strictEqual(config.certPemFile, 'test-cert.pem')
+      assert.strictEqual(config.certKeyFile, 'test-cert.key')
+      assert.strictEqual(config.connectionName, 'test-connection')
+      assert.deepStrictEqual(config.issuers, [
+        'https://api.botframework.com',
+        'https://sts.windows.net/microsoft-tenant-id/',
+        'https://login.microsoftonline.com/microsoft-tenant-id/v2.0'
+      ])
+    })
+
+    it('should throw an error if MicrosoftAppId is not provided in production', () => {
+      process.env.NODE_ENV = 'production'
+      delete process.env.MicrosoftAppId
+      assert.throws(() => loadPrevAuthConfigFromEnv(), /ClientId required in production/)
+    })
+
+    it('should allow missing MicrosoftAppId in development environment', () => {
+      process.env.NODE_ENV = 'development'
+      delete process.env.MicrosoftAppId
+      const config = loadPrevAuthConfigFromEnv()
+      assert.strictEqual(config.clientId, undefined)
+    })
+
+    it('should handle missing optional Microsoft App environment variables', () => {
+      delete process.env.MicrosoftAppPassword
+      delete process.env.MicrosoftAppTenantId
+      delete process.env.MicrosoftAppClientId
+      delete process.env.certPemFile
+      delete process.env.certKeyFile
+      delete process.env.connectionName
+
+      const config = loadPrevAuthConfigFromEnv()
+      assert.strictEqual(config.tenantId, undefined)
+      assert.strictEqual(config.clientSecret, undefined)
+      assert.strictEqual(config.FICClientId, undefined)
+      assert.strictEqual(config.certPemFile, undefined)
+      assert.strictEqual(config.certKeyFile, undefined)
+      assert.strictEqual(config.connectionName, undefined)
+      assert.deepStrictEqual(config.issuers, [
+        'https://api.botframework.com',
+        'https://sts.windows.net/undefined/',
+        'https://login.microsoftonline.com/undefined/v2.0'
+      ])
+    })
+  })
+
+  describe('AuthConfiguration interface', () => {
+    it('should allow creating a valid AuthConfiguration object', () => {
+      const config: AuthConfiguration = {
+        tenantId: 'test-tenant',
+        clientId: 'test-client',
+        clientSecret: 'test-secret',
+        certPemFile: 'cert.pem',
+        certKeyFile: 'cert.key',
+        connectionName: 'test-connection',
+        FICClientId: 'fic-client',
+        issuers: ['https://example.com']
+      }
+
+      assert.strictEqual(config.tenantId, 'test-tenant')
+      assert.strictEqual(config.clientId, 'test-client')
+      assert.strictEqual(config.clientSecret, 'test-secret')
+      assert.strictEqual(config.certPemFile, 'cert.pem')
+      assert.strictEqual(config.certKeyFile, 'cert.key')
+      assert.strictEqual(config.connectionName, 'test-connection')
+      assert.strictEqual(config.FICClientId, 'fic-client')
+      assert.deepStrictEqual(config.issuers, ['https://example.com'])
+    })
+
+    it('should allow creating minimal AuthConfiguration with only required fields', () => {
+      const config: AuthConfiguration = {
+        clientId: 'test-client',
+        issuers: ['https://api.botframework.com']
+      }
+
+      assert.deepStrictEqual(config.issuers, ['https://api.botframework.com'])
+      assert.strictEqual(config.clientId, 'test-client')
+      assert.strictEqual(config.tenantId, undefined)
+    })
+  })
+})

--- a/packages/agents-hosting/test/hosting/testStubs.ts
+++ b/packages/agents-hosting/test/hosting/testStubs.ts
@@ -1,7 +1,13 @@
-import { AttachmentData, AttachmentInfo, BaseAdapter, ResourceResponse, TurnContext } from '../../src'
+import { AttachmentData, AttachmentInfo, AuthConfiguration, BaseAdapter, ResourceResponse, TurnContext } from '../../src'
 import { Activity, ConversationReference } from '@microsoft/agents-activity'
 
 export class TestAdapter extends BaseAdapter {
+  authConfig: AuthConfiguration
+  constructor () {
+    super()
+    this.authConfig = { clientId: 'cid', issuers: [] }
+  }
+
   async sendActivities (context: TurnContext, activities: Activity[]): Promise<ResourceResponse[]> {
     const responses: ResourceResponse[] = []
     for (const activity of activities) {

--- a/samples/mcs/mcsAgent.ts
+++ b/samples/mcs/mcsAgent.ts
@@ -11,14 +11,16 @@ class McsAgent extends AgentApplication<TurnState> {
     super({
       storage: new MemoryStorage(),
       authorization: {
-        mcs: { text: 'Login into MCS', title: 'MCS Login' }
-      }
+        mcs: { text: 'Login into MCS', title: 'MCS Login', cnxPrefix: 'obo' },
+      },
+      startTypingTimer: true,
+      longRunningMessages: false
     })
 
     this.onConversationUpdate('membersAdded', this._status)
     this.authorization.onSignInSuccess(this._singinSuccess)
     this.onMessage('/logout', this._signOut)
-    this.onActivity('invoke', this._invoke)
+    // this.onActivity('invoke', this._invoke)
     this.onActivity('message', this._message, ['mcs'])
   }
 
@@ -35,9 +37,9 @@ class McsAgent extends AgentApplication<TurnState> {
     await context.sendActivity(MessageFactory.text('User signed in successfully'))
   }
 
-  private _invoke = async (context: TurnContext, state: TurnState): Promise<void> => {
-    await context.sendActivity(MessageFactory.text('Invoke received.'))
-  }
+  // private _invoke = async (context: TurnContext, state: TurnState): Promise<void> => {
+  //   await context.sendActivity(MessageFactory.text('Invoke received.'))
+  // }
 
   private _message = async (context: TurnContext, state: TurnState): Promise<void> => {
     const cid = state.getValue<string>('conversation.conversationId')

--- a/samples/mcs/mcsAgent.ts
+++ b/samples/mcs/mcsAgent.ts
@@ -11,7 +11,7 @@ class McsAgent extends AgentApplication<TurnState> {
     super({
       storage: new MemoryStorage(),
       authorization: {
-        mcs: { text: 'Login into MCS', title: 'MCS Login', cnxPrefix: 'obo' },
+        mcs: { text: 'Login into MCS', title: 'MCS Login' },
       },
       startTypingTimer: true,
       longRunningMessages: false

--- a/samples/state/blob2Cnx.ts
+++ b/samples/state/blob2Cnx.ts
@@ -1,0 +1,19 @@
+import { startServer } from '@microsoft/agents-hosting-express'
+import { AgentApplication, loadAuthConfigFromEnv, TurnContext, TurnState, MsalTokenCredential } from '@microsoft/agents-hosting'
+import { BlobsStorage } from '@microsoft/agents-hosting-storage-blob'
+
+const echo = new AgentApplication<TurnState>({
+  storage: new BlobsStorage('', undefined, undefined,
+    'https://asdktdata.blob.core.windows.net/nodejs-conversations',
+    new MsalTokenCredential(loadAuthConfigFromEnv('blob')))
+})
+echo.onConversationUpdate('membersAdded', async (context: TurnContext) => {
+  await context.sendActivity('Welcome to the Blob2Cnx sample, send a message to see the echo feature in action.')
+})
+echo.onActivity('message', async (context: TurnContext, state: TurnState) => {
+  let counter: number = state.getValue('conversation.counter') || 0
+  await context.sendActivity(`[${counter++}]You said: ${context.activity.text}`)
+  state.setValue('conversation.counter', counter)
+})
+
+startServer(echo)


### PR DESCRIPTION
This PR adds the ability to define multiple connections in configuration. To use this, define the connection parameters with a suffix,  eg:

```
blob_tenantId=tenantId
blob_clientId=clientId
blob_clientSecret=clientSecret
```

To use it in the code, call `loadAuthConfigFromEnv('blob')` passing the prefix.

This sample shows how to use a connection to authenticate to blob storage:

https://github.com/microsoft/Agents-for-js/blob/373d8eb86312f4ac76bf9ea846716564d035be86/samples/state/blob2Cnx.ts#L5-L9