### PR TITLE
Update FICClientId retrieval to use connection-specific environment variable

### DIFF
--- a/packages/agents-hosting/src/auth/authConfiguration.ts
+++ b/packages/agents-hosting/src/auth/authConfiguration.ts
@@ -96,7 +96,7 @@ export const loadAuthConfigFromEnv: (cnxName?: string) => AuthConfiguration = (c
       certPemFile: process.env[`${cnxName}_certPemFile`],
       certKeyFile: process.env[`${cnxName}_certKeyFile`],
       connectionName: process.env[`${cnxName}_connectionName`],
-      FICClientId: process.env.FICClientId,
+      FICClientId: process.env[`${cnxName}_FICClientId`],
       issuers: [
         'https://api.botframework.com',
         `https://sts.windows.net/${process.env[`${cnxName}_tenantId`]}/`,

--- a/packages/agents-hosting/test/hosting/authConfiguration.test.ts
+++ b/packages/agents-hosting/test/hosting/authConfiguration.test.ts
@@ -97,7 +97,7 @@ describe('AuthConfiguration', () => {
       assert.strictEqual(config.certPemFile, 'conn-cert.pem')
       assert.strictEqual(config.certKeyFile, 'conn-cert.key')
       assert.strictEqual(config.connectionName, 'conn-connection-name')
-      assert.strictEqual(config.FICClientId, 'test-fic-client-id') // Falls back to global FICClientId
+      assert.strictEqual(config.FICClientId, undefined) // Falls back to global FICClientId
       assert.deepStrictEqual(config.issuers, [
         'https://api.botframework.com',
         'https://sts.windows.net/conn-tenant-id/',
@@ -119,7 +119,7 @@ describe('AuthConfiguration', () => {
       assert.strictEqual(config.certPemFile, undefined)
       assert.strictEqual(config.certKeyFile, undefined)
       assert.strictEqual(config.connectionName, undefined)
-      assert.strictEqual(config.FICClientId, 'test-fic-client-id')
+      assert.strictEqual(config.FICClientId, undefined)
     })
   })
 


### PR DESCRIPTION
This pull request updates the handling of the `FICClientId` environment variable in the `AuthConfiguration` module to make it connection-specific, aligning it with other configuration properties. Corresponding test cases have been updated to reflect this change.

### Updates to `AuthConfiguration`:

* [`packages/agents-hosting/src/auth/authConfiguration.ts`](diffhunk://#diff-5a028c0bf62fd6c9efc8d4189377cfe0f67ad3cec6156b6734cd51c8b94246c6L99-R99): Modified the `FICClientId` property to use a connection-specific environment variable (`${cnxName}_FICClientId`) instead of a global one.

### Updates to tests:

* [`packages/agents-hosting/test/hosting/authConfiguration.test.ts`](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894L100-R100): Updated test cases to expect the `FICClientId` property to be `undefined` when the connection-specific environment variable is not set, instead of falling back to the global `FICClientId`. [[1]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894L100-R100) [[2]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894L122-R122)