### PR TITLE
[#417] Support sovereign / national clouds

### DIFF
--- a/packages/agents-copilotstudio-client/src/connectionSettings.ts
+++ b/packages/agents-copilotstudio-client/src/connectionSettings.ts
@@ -15,6 +15,8 @@ abstract class ConnectionOptions implements Omit<CopilotStudioConnectionSettings
   public appClientId: string = ''
   /** The tenant ID of the application. */
   public tenantId: string = ''
+  /** The login authority to use for the connection */
+  public authority?: string = ''
   /** The environment ID of the application. */
   public environmentId: string = ''
   /** The identifier of the agent. */
@@ -29,8 +31,6 @@ abstract class ConnectionOptions implements Omit<CopilotStudioConnectionSettings
   public directConnectUrl?: string
   /** Flag to use the experimental endpoint if available */
   public useExperimentalEndpoint?: boolean = false
-  /** The login authority to use for the connection */
-  public authority?: string = ''
 }
 
 /**
@@ -65,6 +65,9 @@ export class ConnectionSettings extends ConnectionOptions {
 
     const cloud = options.cloud ?? PowerPlatformCloud.Prod
     const copilotAgentType = options.copilotAgentType ?? AgentType.Published
+    const authority = options.authority && options.authority.trim() !== ''
+      ? options.authority
+      : 'https://login.microsoftonline.com'
 
     if (!Object.values(PowerPlatformCloud).includes(cloud as PowerPlatformCloud)) {
       throw new Error(`Invalid PowerPlatformCloud: '${cloud}'. Supported values: ${Object.values(PowerPlatformCloud).join(', ')}`)
@@ -74,7 +77,7 @@ export class ConnectionSettings extends ConnectionOptions {
       throw new Error(`Invalid AgentType: '${copilotAgentType}'. Supported values: ${Object.values(AgentType).join(', ')}`)
     }
 
-    Object.assign(this, { ...options, cloud, copilotAgentType })
+    Object.assign(this, { ...options, cloud, copilotAgentType, authority })
   }
 }
 
@@ -86,12 +89,13 @@ export const loadCopilotStudioConnectionSettingsFromEnv: () => ConnectionSetting
   return new ConnectionSettings({
     appClientId: process.env.appClientId ?? '',
     tenantId: process.env.tenantId ?? '',
+    authority: process.env.authorityEndpoint ?? 'https://login.microsoftonline.com',
     environmentId: process.env.environmentId ?? '',
     agentIdentifier: process.env.agentIdentifier ?? '',
     cloud: process.env.cloud as PowerPlatformCloud,
     customPowerPlatformCloud: process.env.customPowerPlatformCloud,
     copilotAgentType: process.env.copilotAgentType as AgentType,
     directConnectUrl: process.env.directConnectUrl,
-    useExperimentalEndpoint: process.env.useExperimentalEndpoint?.toLowerCase() === 'true',
-    authority: process.env.authorityEndpoint ?? 'https://login.microsoftonline.com'
+    useExperimentalEndpoint: process.env.useExperimentalEndpoint?.toLowerCase() === 'true'
+  })
 }

--- a/packages/agents-copilotstudio-client/src/connectionSettings.ts
+++ b/packages/agents-copilotstudio-client/src/connectionSettings.ts
@@ -29,6 +29,8 @@ export class ConnectionSettings implements CopilotStudioConnectionSettings {
   public directConnectUrl?: string
   /** Flag to use the experimental endpoint if available */
   public useExperimentalEndpoint?: boolean = false
+  /** The login authority to use for the connection */
+  public authority?: string = ''
 }
 
 /**
@@ -48,6 +50,7 @@ export const loadCopilotStudioConnectionSettingsFromEnv: () => ConnectionSetting
     agentIdentifier: process.env.agentIdentifier,
     copilotAgentType: agentStr ? AgentType[agentStr] : AgentType.Published,
     directConnectUrl: process.env.directConnectUrl,
-    useExperimentalEndpoint: process.env.useExperimentalEndpoint?.toLocaleLowerCase() === 'true'
+    useExperimentalEndpoint: process.env.useExperimentalEndpoint?.toLocaleLowerCase() === 'true',
+    authority: process.env.authorityEndpoint ?? 'https://login.microsoftonline.com'
   } satisfies ConnectionSettings
 }

--- a/packages/agents-copilotstudio-client/src/copilotStudioConnectionSettings.ts
+++ b/packages/agents-copilotstudio-client/src/copilotStudioConnectionSettings.ts
@@ -29,5 +29,8 @@ export interface CopilotStudioConnectionSettings {
   directConnectUrl?: string
 
   /** Directs Copilot Studio Client to use the experimental endpoint if available. */
-  useExperimentalEndpoint?: boolean
+  useExperimentalEndpoint?: boolean,
+
+  /** The login authority to use for the connection. */
+  authority?: string
 }

--- a/packages/agents-hosting/src/auth/jwt-middleware.ts
+++ b/packages/agents-hosting/src/auth/jwt-middleware.ts
@@ -24,7 +24,7 @@ const verifyToken = async (raw: string, config: AuthConfiguration): Promise<JwtP
     logger.info('jwt.decode ', JSON.stringify(payload))
     const jwksUri: string = payload.iss === 'https://api.botframework.com'
       ? 'https://login.botframework.com/v1/.well-known/keys'
-      : `https://login.microsoftonline.com/${config.tenantId}/discovery/v2.0/keys`
+      : `${config.authority}/${config.tenantId}/discovery/v2.0/keys`
 
     logger.info(`fetching keys from ${jwksUri}`)
     const jwksClient: JwksClient = jwksRsa({ jwksUri })

--- a/packages/agents-hosting/src/auth/msalTokenProvider.ts
+++ b/packages/agents-hosting/src/auth/msalTokenProvider.ts
@@ -55,7 +55,7 @@ export class MsalTokenProvider implements AuthProvider {
     const cca = new ConfidentialClientApplication({
       auth: {
         clientId: authConfig.clientId as string,
-        authority: `https://login.microsoftonline.com/${authConfig.tenantId || 'botframework.com'}`,
+        authority: `${authConfig.authority}/${authConfig.tenantId || 'botframework.com'}`,
         clientSecret: authConfig.clientSecret
       },
       system: this.sysOptions
@@ -137,7 +137,7 @@ export class MsalTokenProvider implements AuthProvider {
     const cca = new ConfidentialClientApplication({
       auth: {
         clientId: authConfig.clientId || '',
-        authority: `https://login.microsoftonline.com/${authConfig.tenantId || 'botframework.com'}`,
+        authority: `${authConfig.authority}/${authConfig.tenantId || 'botframework.com'}`,
         clientCertificate: {
           privateKey: privateKey as string,
           thumbprint: pubKeyObject.fingerprint.replaceAll(':', ''),
@@ -163,7 +163,7 @@ export class MsalTokenProvider implements AuthProvider {
     const cca = new ConfidentialClientApplication({
       auth: {
         clientId: authConfig.clientId as string,
-        authority: `https://login.microsoftonline.com/${authConfig.tenantId || 'botframework.com'}`,
+        authority: `${authConfig.authority}/${authConfig.tenantId || 'botframework.com'}`,
         clientSecret: authConfig.clientSecret
       },
       system: this.sysOptions
@@ -187,7 +187,7 @@ export class MsalTokenProvider implements AuthProvider {
     const cca = new ConfidentialClientApplication({
       auth: {
         clientId: authConfig.clientId as string,
-        authority: `https://login.microsoftonline.com/${authConfig.tenantId}`,
+        authority: `${authConfig.authority}/${authConfig.tenantId}`,
         clientAssertion
       },
       system: this.sysOptions

--- a/packages/agents-hosting/test/hosting/authConfiguration.test.ts
+++ b/packages/agents-hosting/test/hosting/authConfiguration.test.ts
@@ -17,6 +17,7 @@ describe('AuthConfiguration', () => {
     process.env.certKeyFile = 'test-cert.key'
     process.env.connectionName = 'test-connection'
     process.env.FICClientId = 'test-fic-client-id'
+    process.env.authorityEndpoint = 'https://login.microsoftonline.com'
     process.env.NODE_ENV = 'development'
   })
 
@@ -40,6 +41,7 @@ describe('AuthConfiguration', () => {
         'https://sts.windows.net/test-tenant-id/',
         'https://login.microsoftonline.com/test-tenant-id/v2.0'
       ])
+      assert.strictEqual(config.authority, 'https://login.microsoftonline.com')
     })
 
     it('should throw an error if clientId is not provided in production', () => {
@@ -62,6 +64,7 @@ describe('AuthConfiguration', () => {
       delete process.env.certKeyFile
       delete process.env.connectionName
       delete process.env.FICClientId
+      delete process.env.authorityEndpoint
 
       const config = loadAuthConfigFromEnv()
       assert.strictEqual(config.tenantId, undefined)
@@ -75,6 +78,7 @@ describe('AuthConfiguration', () => {
         'https://sts.windows.net/undefined/',
         'https://login.microsoftonline.com/undefined/v2.0'
       ])
+      assert.strictEqual(config.authority, 'https://login.microsoftonline.com')
     })
   })
 
@@ -87,6 +91,7 @@ describe('AuthConfiguration', () => {
       process.env.myconn_certPemFile = 'conn-cert.pem'
       process.env.myconn_certKeyFile = 'conn-cert.key'
       process.env.myconn_connectionName = 'conn-connection-name'
+      process.env.myconn_authorityEndpoint = 'https://login.microsoftonline.com'
     })
 
     it('should load configuration from connection-specific environment variables', () => {
@@ -103,6 +108,7 @@ describe('AuthConfiguration', () => {
         'https://sts.windows.net/conn-tenant-id/',
         'https://login.microsoftonline.com/conn-tenant-id/v2.0'
       ])
+      assert.strictEqual(config.authority, 'https://login.microsoftonline.com')
     })
 
     it('should throw an error if connection-specific clientId is not found', () => {
@@ -120,6 +126,7 @@ describe('AuthConfiguration', () => {
       assert.strictEqual(config.certKeyFile, undefined)
       assert.strictEqual(config.connectionName, undefined)
       assert.strictEqual(config.FICClientId, undefined)
+      assert.deepStrictEqual(config.authority, 'https://login.microsoftonline.com')
     })
   })
 
@@ -146,6 +153,7 @@ describe('AuthConfiguration', () => {
         'https://sts.windows.net/microsoft-tenant-id/',
         'https://login.microsoftonline.com/microsoft-tenant-id/v2.0'
       ])
+      assert.strictEqual(config.authority, 'https://login.microsoftonline.com')
     })
 
     it('should throw an error if MicrosoftAppId is not provided in production', () => {
@@ -168,6 +176,7 @@ describe('AuthConfiguration', () => {
       delete process.env.certPemFile
       delete process.env.certKeyFile
       delete process.env.connectionName
+      delete process.env.authorityEndpoint
 
       const config = loadPrevAuthConfigFromEnv()
       assert.strictEqual(config.tenantId, undefined)
@@ -181,6 +190,7 @@ describe('AuthConfiguration', () => {
         'https://sts.windows.net/undefined/',
         'https://login.microsoftonline.com/undefined/v2.0'
       ])
+      assert.strictEqual(config.authority, 'https://login.microsoftonline.com')
     })
   })
 
@@ -194,7 +204,8 @@ describe('AuthConfiguration', () => {
         certKeyFile: 'cert.key',
         connectionName: 'test-connection',
         FICClientId: 'fic-client',
-        issuers: ['https://example.com']
+        issuers: ['https://example.com'],
+        authority: 'https://login.microsoftonline.us'
       }
 
       assert.strictEqual(config.tenantId, 'test-tenant')
@@ -205,6 +216,7 @@ describe('AuthConfiguration', () => {
       assert.strictEqual(config.connectionName, 'test-connection')
       assert.strictEqual(config.FICClientId, 'fic-client')
       assert.deepStrictEqual(config.issuers, ['https://example.com'])
+      assert.strictEqual(config.authority, 'https://login.microsoftonline.us')
     })
 
     it('should allow creating minimal AuthConfiguration with only required fields', () => {

--- a/test-agents/copilotstudio-console/env.TEMPLATE
+++ b/test-agents/copilotstudio-console/env.TEMPLATE
@@ -1,6 +1,7 @@
 # rename to .env
 appClientId="" # App ID of the App Registration used to log in, this should be in the same tenant as the Copilot.
 tenantId="" # Tenant ID of the App Registration used to log in, this should be in the same tenant as the Copilot.
+authorityEndpoint="" # Login authority to use for the connection. Default value is "https://login.microsoftonline.com".
 environmentId="" # Environment ID of the environment with the Copilot Studio App.
 cloud="" # PowerPlatformCloud enum key.
 customPowerPlatformCloud="" # Power Platform API endpoint to use if Cloud is configured as "Other".

--- a/test-agents/copilotstudio-console/src/index.ts
+++ b/test-agents/copilotstudio-console/src/index.ts
@@ -71,7 +71,7 @@ function getToken (settings: ConnectionSettings) : Promise<string> {
   const msalConfig: msal.Configuration = {
     auth: {
       clientId: settings.appClientId!,
-      authority: `https://login.microsoftonline.com/${settings.tenantId}`,
+      authority: `${settings.authority}/${settings.tenantId}`,
     },
     cache: {
       cachePlugin: new MsalCachePlugin(path.join(os.tmpdir(), 'msal.usercache.json'))

--- a/test-agents/copilotstudio-webchat/acquireToken.js
+++ b/test-agents/copilotstudio-webchat/acquireToken.js
@@ -9,7 +9,7 @@ export async function acquireToken (settings) {
   const msalInstance = new window.msal.PublicClientApplication({
     auth: {
       clientId: settings.appClientId,
-      authority: `https://login.microsoftonline.com/${settings.tenantId}`,
+      authority: `${settings.authority}/${settings.tenantId}`,
     },
   })
 

--- a/test-agents/copilotstudio-webchat/settings.js
+++ b/test-agents/copilotstudio-webchat/settings.js
@@ -15,7 +15,7 @@ export const settings = new ConnectionSettings({
   // Tenant ID of the App Registration used to log in, this should be in the same tenant as the Copilot.
   tenantId: '',
   // Authority endpoint for the Azure AD login. Default is 'https://login.microsoftonline.com'.
-  authority: 'https://login.microsoftonline.com',
+  authority: '',
   // Environment ID of the environment with the Copilot Studio App.
   environmentId: '',
   // Schema Name of the Copilot to use.

--- a/test-agents/copilotstudio-webchat/settings.js
+++ b/test-agents/copilotstudio-webchat/settings.js
@@ -26,4 +26,5 @@ export const settings = {
   directConnectUrl: '',
   // Flag to use the "x-ms-d2e-experimental" header URL on subsequent calls to the Copilot Studio service.
   useExperimentalEndpoint: false,
+  authority: 'https://login.microsoftonline.com', // Authority endpoint for the Azure AD login. Default is 'https://login.microsoftonline.com'.
 }


### PR DESCRIPTION
Fixes #417

## Description
This PR contains the changes to make the authority endpoint configurable, allowing the use of national clouds in _CopilotStudioClient_ and _Agents-Hosting_ packages.
The default value is the public cloud URL: https://login.microsoftonline.com.

## Detailed Changes
- Added the **_authorityEndpoint_** property in:
   - ConnectionSettings
   - copilotStudioConnectionSettings
   - authConfiguration
- Replaced hard-coded values with the value read from the configuration in **_msalTokenProvider_** and **_jwt-middleware_**
- Updated unit tests to verify the correct population of the property in **_authConfiguration.test.ts_**
- Updated copilotstudio-console and copilotstudio-webchat samples to use the authority from the settings.

## Testing
These images show the samples working after the changes
<img width="2187" height="1627" alt="image" src="https://github.com/user-attachments/assets/a2ef796f-5058-437e-9187-27f794372db9" />
