### PR TITLE
[#78] jwtMiddleware throws at startup

### DIFF
--- a/packages/agents-hosting/src/auth/jwt-middleware.ts
+++ b/packages/agents-hosting/src/auth/jwt-middleware.ts
@@ -74,7 +74,7 @@ export const authorizeJWT = (authConfig: AuthConfiguration) => {
     logger.debug('authorizing jwt')
     if (req.method !== 'POST' && req.method !== 'GET') {
       failed = true
-      logger.error('Method not allowed', req.method)
+      logger.warn('Method not allowed', req.method)
       res.status(405).send({ 'jwt-auth-error': 'Method not allowed' })
     } else {
       const authHeader = req.headers.authorization as string

--- a/packages/agents-hosting/src/auth/jwt-middleware.ts
+++ b/packages/agents-hosting/src/auth/jwt-middleware.ts
@@ -72,25 +72,32 @@ export const authorizeJWT = (authConfig: AuthConfiguration) => {
   return async function (req: Request, res: Response, next: NextFunction) {
     let failed = false
     logger.debug('authorizing jwt')
-    const authHeader = req.headers.authorization as string
-    if (authHeader) {
-      const token: string = authHeader.split(' ')[1] // Extract the token from the Bearer string
-      try {
-        const user = await verifyToken(token, authConfig)
-        logger.debug('token verified for ', user)
-        req.user = user
-      } catch (err: Error | any) {
-        failed = true
-        logger.error(err)
-        res.status(401).send({ 'jwt-auth-error': err.message })
-      }
+    if (req.method !== 'POST' && req.method !== 'GET') {
+      failed = true
+      logger.error('Method not allowed', req.method)
+      res.status(405).send({ 'jwt-auth-error': 'Method not allowed' })
     } else {
-      if (!authConfig.clientId && process.env.NODE_ENV !== 'production') {
-        logger.info('using anonymous auth')
-        req.user = { name: 'anonymous' }
+      const authHeader = req.headers.authorization as string
+      if (authHeader) {
+        const token: string = authHeader.split(' ')[1] // Extract the token from the Bearer string
+        try {
+          const user = await verifyToken(token, authConfig)
+          logger.debug('token verified for ', user)
+          req.user = user
+        } catch (err: Error | any) {
+          failed = true
+          logger.error(err)
+          res.status(401).send({ 'jwt-auth-error': err.message })
+        }
       } else {
-        logger.error('authorization header not found')
-        res.status(401).send({ 'jwt-auth-error': 'authorization header not found' })
+        if (!authConfig.clientId && process.env.NODE_ENV !== 'production') {
+          logger.info('using anonymous auth')
+          req.user = { name: 'anonymous' }
+        } else {
+          failed = true
+          logger.error('authorization header not found')
+          res.status(401).send({ 'jwt-auth-error': 'authorization header not found' })
+        }
       }
     }
     if (!failed) {

--- a/packages/agents-hosting/test/hosting/jwt-middleware.test.ts
+++ b/packages/agents-hosting/test/hosting/jwt-middleware.test.ts
@@ -13,7 +13,8 @@ describe('authorizeJWT', () => {
 
   beforeEach(() => {
     req = {
-      headers: {}
+      headers: {},
+      method: 'POST',
     }
     res = {
       status: sinon.stub().returnsThis(),
@@ -51,8 +52,8 @@ describe('authorizeJWT', () => {
     await authorizeJWT(config)(req as Request, res as Response, next)
 
     assert((res.status as sinon.SinonStub).calledOnceWith(401))
-    // assert((res.send as sinon.SinonStub).calledOnceWith({ error: 'Unauthorized' }))
-    // assert((next as sinon.SinonStub).notCalled)
+    assert((res.send as sinon.SinonStub).calledOnceWith({ 'jwt-auth-error': 'authorization header not found' }))
+    assert((next as sinon.SinonStub).notCalled)
   })
 
   it('should respond with 401 if token is invalid', async () => {
@@ -68,9 +69,19 @@ describe('authorizeJWT', () => {
     await authorizeJWT(config)(req as Request, res as Response, next)
 
     assert((res.status as sinon.SinonStub).calledOnceWith(401))
-    // assert((res.send as sinon.SinonStub).calledOnceWith({ error: 'Unauthorized' }))
+    assert((res.send as sinon.SinonStub).calledOnceWith({ 'jwt-auth-error': 'invalid token' }))
     assert((next as sinon.SinonStub).notCalled)
 
     verifyStub.restore()
+  })
+
+  it('should respond with 405 if method not allowed', async () => {
+    req.method = 'OPTIONS' // Simulate a method that is not allowed
+
+    await authorizeJWT(config)(req as Request, res as Response, next)
+
+    assert((res.status as sinon.SinonStub).calledOnceWith(405))
+    assert((res.send as sinon.SinonStub).calledOnceWith({ 'jwt-auth-error': 'Method not allowed' }))
+    assert((next as sinon.SinonStub).notCalled)
   })
 })


### PR DESCRIPTION
Fixes #78

## Description
This PR fixes the error thrown by the **_jwtMiddleware_** when trying to get the authorization header from a request that does not include it. It adds a validation to return _405 Method not allowed_ responsense when the request is neither POST nor GET.
It also adds a new unit test to cover this case.

## Detailed Changes
- Updated **jwt-middleware** to:
   - Include the new _method_ validation.
   - Set the _failed_ flag to true when it can't retrieve the authorization header. This will prevent the execution to continue after sending the response and the `Cannot set headers after they are sent to the client` error.
- Added a unit test in **jwt-middleware.test** and update the existing ones to assert the next function not being called.

## Testing
The images illustrate the handling of an OPTIONS method request before the changes and the improvements implemented after the fix.
<img width="2571" height="795" alt="image" src="https://github.com/user-attachments/assets/462bf8b6-b541-4418-85c9-c3b294d49621" />