### PR TITLE
Update dependencies for eslint, typedoc, and @azure/storage-blob

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,14 +21,14 @@
         "@types/sinon": "^17.0.4",
         "@types/uuid": "^10.0.0",
         "esbuild": "^0.25.4",
-        "eslint": "^9.31.0",
+        "eslint": "^9.32.0",
         "global": "4.4.0",
         "neostandard": "^0.12.2",
         "nerdbank-gitversioning": "^3.7.115",
         "npm-run-all": "^4.1.5",
         "sinon": "^21.0.0",
         "tsx": "^4.20.3",
-        "typedoc": "^0.28.4",
+        "typedoc": "^0.28.8",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -268,29 +268,48 @@
       }
     },
     "node_modules/@azure/storage-blob": {
-      "version": "12.27.0",
+      "version": "12.28.0",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
-        "@azure/core-auth": "^1.4.0",
-        "@azure/core-client": "^1.6.2",
-        "@azure/core-http-compat": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.3",
+        "@azure/core-http-compat": "^2.2.0",
         "@azure/core-lro": "^2.2.0",
-        "@azure/core-paging": "^1.1.1",
-        "@azure/core-rest-pipeline": "^1.10.1",
-        "@azure/core-tracing": "^1.1.2",
-        "@azure/core-util": "^1.6.1",
-        "@azure/core-xml": "^1.4.3",
-        "@azure/logger": "^1.0.0",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/core-xml": "^1.4.5",
+        "@azure/logger": "^1.1.4",
+        "@azure/storage-common": "^12.0.0-beta.2",
         "events": "^3.0.0",
-        "tslib": "^2.2.0"
+        "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/storage-common": {
+      "version": "12.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.1.4",
+        "events": "^3.3.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.6",
+      "version": "7.28.2",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -805,7 +824,7 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.31.0",
+      "version": "9.32.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1189,12 +1208,11 @@
       }
     },
     "node_modules/@sinonjs/samsam": {
-      "version": "8.0.2",
+      "version": "8.0.3",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
-        "lodash.get": "^4.4.2",
         "type-detect": "^4.1.0"
       }
     },
@@ -2904,7 +2922,7 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.31.0",
+      "version": "9.32.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2914,8 +2932,8 @@
         "@eslint/config-helpers": "^0.3.0",
         "@eslint/core": "^0.15.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.31.0",
-        "@eslint/plugin-kit": "^0.3.1",
+        "@eslint/js": "9.32.0",
+        "@eslint/plugin-kit": "^0.3.4",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -3102,7 +3120,7 @@
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "17.21.0",
+      "version": "17.21.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3111,8 +3129,8 @@
         "eslint-plugin-es-x": "^7.8.0",
         "get-tsconfig": "^4.8.1",
         "globals": "^15.11.0",
+        "globrex": "^0.1.2",
         "ignore": "^5.3.2",
-        "minimatch": "^9.0.5",
         "semver": "^7.6.3",
         "ts-declaration-location": "^1.0.6"
       },
@@ -3126,14 +3144,6 @@
         "eslint": ">=8.23.0"
       }
     },
-    "node_modules/eslint-plugin-n/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/eslint-plugin-n/node_modules/globals": {
       "version": "15.15.0",
       "dev": true,
@@ -3143,20 +3153,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-n/node_modules/minimatch": {
-      "version": "9.0.5",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/eslint-plugin-promise": {
@@ -3731,6 +3727,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -4573,12 +4574,6 @@
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -6319,7 +6314,7 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.28.7",
+      "version": "0.28.8",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6741,7 +6736,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@azure/storage-blob": "^12.27.0",
+        "@azure/storage-blob": "^12.28.0",
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -43,18 +43,17 @@
     "@types/sinon": "^17.0.4",
     "@types/uuid": "^10.0.0",
     "esbuild": "^0.25.4",
-    "eslint": "^9.31.0",
+    "eslint": "^9.32.0",
     "global": "4.4.0",
     "neostandard": "^0.12.2",
     "nerdbank-gitversioning": "^3.7.115",
     "npm-run-all": "^4.1.5",
     "sinon": "^21.0.0",
     "tsx": "^4.20.3",
-    "typedoc": "^0.28.4",
+    "typedoc": "^0.28.8",
     "typescript": "^5.8.3"
   },
   "engines": {
     "node": ">=20.0.0"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/packages/agents-hosting-storage-blob/package.json
+++ b/packages/agents-hosting-storage-blob/package.json
@@ -16,7 +16,7 @@
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",
   "dependencies": {
-    "@azure/storage-blob": "^12.27.0",
+    "@azure/storage-blob": "^12.28.0",
     "@microsoft/agents-hosting": "file:../../packages/agents-hosting"
   },
   "license": "MIT",


### PR DESCRIPTION
Upgrade eslint, typedoc, and @azure/storage-blob to their latest versions to ensure compatibility and access to new features.