### PR TITLE
[#482] Manual Authentication failing on test-agents/copilotstudio-webchat

### DIFF
--- a/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
+++ b/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
@@ -191,6 +191,16 @@ export class CopilotStudioClient {
     }
     const activity = Activity.fromObject(activityObj)
 
+    return this.sendActivity(activity)
+  }
+
+  /**
+   * Sends an activity to the Copilot Studio service and retrieves the response activities.
+   * @param activity The activity to send.
+   * @param conversationId The ID of the conversation. Defaults to the current conversation ID.
+   * @returns A promise that resolves to an array of activities containing the responses.
+   */
+  public async sendActivity (activity: Activity, conversationId: string = this.conversationId) {
     const localConversationId = activity.conversation?.id ?? conversationId
     const uriExecute = getCopilotStudioConnectionUrl(this.settings, localConversationId)
     const qbody: ExecuteTurnRequest = new ExecuteTurnRequest(activity)
@@ -206,7 +216,7 @@ export class CopilotStudioClient {
       responseType: 'stream',
       adapter: 'fetch'
     }
-    logger.info(`Asking question: ${question} ...`)
+    logger.info(`Sending activity: ${JSON.stringify(activity)} ...`)
     const values = await this.postRequestAsync(config)
     logger.info(`Received ${values.length} activities.`, values)
     return values

--- a/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
+++ b/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
@@ -216,7 +216,7 @@ export class CopilotStudioClient {
       responseType: 'stream',
       adapter: 'fetch'
     }
-    logger.info(`Sending activity: ${JSON.stringify(activity)} ...`)
+    logger.info(`Sending activity...`, activity)
     const values = await this.postRequestAsync(config)
     logger.info(`Received ${values.length} activities.`, values)
     return values

--- a/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
+++ b/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
@@ -216,7 +216,7 @@ export class CopilotStudioClient {
       responseType: 'stream',
       adapter: 'fetch'
     }
-    logger.info(`Sending activity...`, activity)
+    logger.info('Sending activity...', activity)
     const values = await this.postRequestAsync(config)
     logger.info(`Received ${values.length} activities.`, values)
     return values

--- a/packages/agents-copilotstudio-client/src/copilotStudioWebChat.ts
+++ b/packages/agents-copilotstudio-client/src/copilotStudioWebChat.ts
@@ -68,7 +68,7 @@ export interface CopilotStudioWebChatConnection {
    * The method validates that the activity contains meaningful content and handles
    * the complete message flow including optional typing indicators.
    *
-   * @param activity - The user activity to send. Must contain a non-empty text field.
+   * @param activity - The user activity to send.
    * @returns An observable that emits the unique activity ID upon successful posting.
    * @throws Error if the activity text is empty or if the connection is not properly initialized.
    */
@@ -254,8 +254,8 @@ export class CopilotStudioWebChat {
       postActivity (activity: Activity) {
         logger.info('--> Preparing to send activity to Copilot Studio ...')
 
-        if (!activity.text?.trim()) {
-          throw new Error('Activity text cannot be empty.')
+        if (!activity) {
+          throw new Error('Activity cannot be null.')
         }
 
         if (!activitySubscriber) {
@@ -271,7 +271,8 @@ export class CopilotStudioWebChat {
             notifyActivity({ ...activity, id })
             notifyTyping()
 
-            const activities = await client.askQuestionAsync(activity.text!)
+            const activities = await client.sendActivity(activity)
+
             for (const responseActivity of activities) {
               notifyActivity(responseActivity)
             }


### PR DESCRIPTION
Fixes #482
Fixes #450

## Description
This PR fixes an issue in `copilotstudioclient` where only activities with _text_ were supported. 
The activity generated for the Office 365 consent card, for example, doesn't have a _text_; instead, the value of the clicked button is sent in the _activity.value_ property.

```JSON
{
  "activity": {
    "attachments": [],
    "channelData": {
      "clientActivityID": "9dfcaq9stpc",
      "postBack": true,
    },
    "channelId": "webchat",
    "from": {
      "id": "r_nhl5eooup9",
      "name": "",
      "role": "user"
    },
    "localTimestamp": "2025-08-01T16:42:33.718-03:00",
    "localTimezone": "America/Buenos_Aires",
    "locale": "en",
    "text": undefined,
    "type": "message",
    "value": {
       "action": "Allow"
     }
  },
}
```


## Detailed Changes
- Created a new **_sendActivity_** function to post the activity to the Copilot Studio API.
- Updated **_askQuestionAsync_** function to call the new sendActivity method after creating the activity with the question's text.
- Replaced the call to _askQuestionAsync_ with _sendActivity_ in **_copilotStudioWebChat_** allowing activities with no text, like the one used in Office 365 consent cards.

## Testing
This image shows the WebChat sample working with Manual Authentication. After pressing the "Allow" button, the Office 365 resource was successfully accessed, and an email was sent by the agent.
<img width="1691" height="773" alt="image" src="https://github.com/user-attachments/assets/b2049815-d3c9-479e-8953-429412b48fa3" />