### PR TITLE
[#466] SSO flows not completed when running multiple instances

### DIFF
--- a/packages/agents-hosting/src/app/authorization.ts
+++ b/packages/agents-hosting/src/app/authorization.ts
@@ -6,8 +6,8 @@
 import { TurnContext } from '../turnContext'
 import { debug } from '@microsoft/agents-activity/logger'
 import { TurnState } from './turnState'
-import { Storage } from '../storage'
-import { OAuthFlow, TokenResponse, UserTokenClient } from '../oauth'
+import { MemoryStorage, Storage } from '../storage'
+import { FlowState, OAuthFlow, TokenResponse, UserTokenClient } from '../oauth'
 import { AuthConfiguration, loadAuthConfigFromEnv, MsalTokenProvider } from '../auth'
 import jwt, { JwtPayload } from 'jsonwebtoken'
 import { Activity } from '@microsoft/agents-activity'
@@ -15,16 +15,35 @@ import { Activity } from '@microsoft/agents-activity'
 const logger = debug('agents:authorization')
 
 /**
- * Represents the state of a sign-in process.
- * @interface SignInState
+ * Represents the response from beginning or continuing an OAuth flow.
+ * @interface BeginOrContinueFlowResponse
  */
-export interface SignInState {
-  /** Optional activity to continue with after sign-in completion. */
-  continuationActivity?: Activity,
+export interface BeginOrContinueFlowResponse extends TokenResponse {
+  handler?: SignInHandlerState
+}
+
+/**
+ * Represents the state of a sign-in process.
+ * @interface SignInHandlerState
+ */
+export interface SignInHandlerState {
   /** Identifier of the auth handler being used. */
-  handlerId?: string,
-  /** Whether the sign-in process has been completed. */
-  completed?: boolean
+  id: string,
+  /**
+   * Current status of the sign-in process.
+   * @remarks
+   * Order of execution: begin -> continue -> success
+   *
+   * - **begin**: [begin] Initial state, no flow started.
+   * - **continue**: [continue] OAuth flow has started, waiting for user interaction.
+   * - **success**: [auth success] OAuth flow success, token available.
+   * - **failure**: [auth failure] OAuth flow failure, no token available. Removed from storage.
+  */
+  status: 'begin' | 'continue' | 'success' | 'failure'
+  /** Optional state of the OAuth flow, if applicable. */
+  state?: FlowState
+  /** Optional activity to continue with after sign-in completion. */
+  continuationActivity?: Activity
 }
 
 /**
@@ -85,6 +104,23 @@ export interface AuthorizationHandlers extends Record<string, AuthHandler> {}
  */
 export class Authorization {
   /**
+   * Private handler for successful sign-in events.
+   * @private
+   */
+  private _signInSuccessHandler: ((context: TurnContext, state: TurnState, authHandlerId?: string) => Promise<void> | void) | null = null
+
+  /**
+   * Private handler for failed sign-in events.
+   * @private
+   */
+  private _signInFailureHandler: ((context: TurnContext, state: TurnState, authHandlerId?: string, errorMessage?: string) => Promise<void> | void) | null = null
+  /**
+   * Storage instance used for managing sign-in state.
+   * @private
+   */
+  private _signInStorage: SignInStorage
+
+  /**
    * Dictionary of configured authentication handlers.
    * @public
    */
@@ -135,9 +171,23 @@ export class Authorization {
       currentAuthHandler.title = currentAuthHandler.title ?? process.env[ah + '_connectionTitle'] as string
       currentAuthHandler.text = currentAuthHandler.text ?? process.env[ah + '_connectionText'] as string
       currentAuthHandler.cnxPrefix = currentAuthHandler.cnxPrefix ?? process.env[ah + '_cnxPrefix'] as string
-      currentAuthHandler.flow = new OAuthFlow(this.storage, currentAuthHandler.name, userTokenClient, currentAuthHandler.title, currentAuthHandler.text)
+      // Add MemoryStorage to OAuthFlow since this class handles the storage state.
+      currentAuthHandler.flow = new OAuthFlow(new MemoryStorage(), currentAuthHandler.name, userTokenClient, currentAuthHandler.title, currentAuthHandler.text)
     }
     logger.info('Authorization handlers configured with', Object.keys(this.authHandlers).length, 'handlers')
+    this._signInStorage = new SignInStorage(this.storage, this.authHandlers)
+  }
+
+  /**
+   * Creates a sign-in context for managing OAuth flows.
+   *
+   * @param context - The context object for the current turn.
+   * @param handlerId - Optional ID of the auth handler to use.
+   * @param useStorageState - Whether to use storage state for the sign-in handler.
+   * @private
+   */
+  private createSignInContext (context: TurnContext, handlerId?: string, useStorageState: boolean = true): SignInContext {
+    return new SignInContext(this._signInStorage, this.authHandlers, context, handlerId, useStorageState)
   }
 
   /**
@@ -162,25 +212,9 @@ export class Authorization {
    *
    * @public
    */
-  public async getToken (context: TurnContext, authHandlerId: string): Promise<TokenResponse> {
-    logger.info('getToken from user token service for authHandlerId:', authHandlerId)
-    const authHandler = this.getAuthHandlerOrThrow(authHandlerId)
-    return await authHandler.flow?.getUserToken(context)!
-  }
-
-  /**
-   * Gets the auth handler by ID or throws an error if not found.
-   *
-   * @param authHandlerId - ID of the auth handler to retrieve.
-   * @returns The auth handler instance.
-   * @throws {Error} If the auth handler with the specified ID is not configured.
-   * @private
-   */
-  private getAuthHandlerOrThrow (authHandlerId: string): AuthHandler {
-    if (!Object.prototype.hasOwnProperty.call(this.authHandlers, authHandlerId)) {
-      throw new Error(`AuthHandler with ID ${authHandlerId} not configured`)
-    }
-    return this.authHandlers[authHandlerId]
+  public getToken (context: TurnContext, authHandlerId: string): Promise<TokenResponse> {
+    const signInContext = this.createSignInContext(context, authHandlerId)
+    return signInContext.getUserToken()
   }
 
   /**
@@ -208,48 +242,9 @@ export class Authorization {
    *
    * @public
    */
-  public async exchangeToken (context: TurnContext, scopes: string[], authHandlerId: string): Promise<TokenResponse> {
-    logger.info('exchangeToken from user token service for authHandlerId:', authHandlerId)
-    const authHandler = this.getAuthHandlerOrThrow(authHandlerId)
-    const tokenResponse = await authHandler.flow?.getUserToken(context)!
-    if (this.isExchangeable(tokenResponse.token)) {
-      return await this.handleObo(context, tokenResponse.token!, scopes, authHandler.cnxPrefix)
-    }
-    return tokenResponse
-  }
-
-  /**
-   * Checks if a token is exchangeable for an on-behalf-of flow.
-   *
-   * @param token - The token to check.
-   * @returns True if the token is exchangeable, false otherwise.
-   * @private
-   */
-  private isExchangeable (token: string | undefined): boolean {
-    if (!token || typeof token !== 'string') {
-      return false
-    }
-    const payload = jwt.decode(token) as JwtPayload
-    return payload?.aud?.indexOf('api://') === 0
-  }
-
-  /**
-   * Handles on-behalf-of token exchange using MSAL.
-   *
-   * @param context - The context object for the current turn.
-   * @param token - The token to exchange.
-   * @param scopes - Array of scopes to request for the new token.
-   * @returns A promise that resolves to the exchanged token response.
-   * @private
-   */
-  private async handleObo (context: TurnContext, token: string, scopes: string[], cnxPrefix?: string): Promise<TokenResponse> {
-    const msalTokenProvider = new MsalTokenProvider()
-    let authConfig: AuthConfiguration = context.adapter.authConfig
-    if (cnxPrefix) {
-      authConfig = loadAuthConfigFromEnv(cnxPrefix)
-    }
-    const newToken = await msalTokenProvider.acquireTokenOnBehalfOf(authConfig, scopes, token)
-    return { token: newToken }
+  public exchangeToken (context: TurnContext, scopes: string[], authHandlerId: string): Promise<TokenResponse> {
+    const signInContext = this.createSignInContext(context, authHandlerId)
+    return signInContext.exchangeToken(scopes)
   }
 
   /**
@@ -281,49 +276,13 @@ export class Authorization {
    *
    * @public
    */
-  public async beginOrContinueFlow (context: TurnContext, state: TurnState, authHandlerId: string, secRoute: boolean = true) : Promise<TokenResponse> {
-    const authHandler = this.getAuthHandlerOrThrow(authHandlerId)
-    logger.info('beginOrContinueFlow for authHandlerId:', authHandlerId)
-    const signInState: SignInState | undefined = state.getValue('user.__SIGNIN_STATE_') || { continuationActivity: undefined, handlerId: undefined, completed: false }
-    const flow = authHandler.flow!
-    let tokenResponse: TokenResponse | undefined
-    tokenResponse = await authHandler.flow?.getUserToken(context)
+  public async beginOrContinueFlow (context: TurnContext, state: TurnState, authHandlerId?: string, useStorageState: boolean = true) : Promise<BeginOrContinueFlowResponse> {
+    const signInContext = this.createSignInContext(context, authHandlerId, useStorageState)
+    signInContext.onSuccess(() => this._signInSuccessHandler?.(context, state, signInContext.handler.id))
+    signInContext.onFailure((err) => this._signInFailureHandler?.(context, state, signInContext.handler.id, err))
 
-    if (tokenResponse?.token && tokenResponse.token.length > 0) {
-      delete authHandler.flow?.state.eTag
-      authHandler.flow!.state.flowStarted = false
-      await authHandler.flow?.setFlowState(context, authHandler.flow.state)
-      if (secRoute) {
-        return tokenResponse!
-      }
-    }
-
-    if (flow.state === null || flow.state?.flowStarted === false || flow.state?.flowStarted === undefined) {
-      tokenResponse = await flow.beginFlow(context)
-      if (secRoute && tokenResponse?.token === undefined) {
-        signInState!.continuationActivity = context.activity
-        signInState!.handlerId = authHandlerId
-        state.setValue('user.__SIGNIN_STATE_', signInState)
-      }
-    } else {
-      tokenResponse = await flow.continueFlow(context)
-      if (tokenResponse && tokenResponse.token) {
-        if (this._signInSuccessHandler) {
-          await this._signInSuccessHandler(context, state, authHandlerId)
-        }
-        if (secRoute) {
-          state.deleteValue('user.__SIGNIN_STATE_')
-        }
-      } else {
-        logger.warn('Failed to complete OAuth flow, no token received')
-        if (this._signInFailureHandler) {
-          await this._signInFailureHandler(context, state, authHandlerId, 'Failed to complete the OAuth flow')
-        }
-        // signInState!.completed = false
-        // state.setValue('user.__SIGNIN_STATE_', signInState)
-      }
-    }
-    return tokenResponse!
+    const tokenResponse = await signInContext.getToken()
+    return { token: tokenResponse?.token, handler: signInContext.handler }
   }
 
   /**
@@ -352,23 +311,16 @@ export class Authorization {
    * @public
    */
   async signOut (context: TurnContext, state: TurnState, authHandlerId?: string) : Promise<void> {
-    logger.info('signOut for authHandlerId:', authHandlerId)
-    if (authHandlerId === undefined) { // aw
-      for (const ah in this.authHandlers) {
-        const flow = this.authHandlers[ah].flow
-        await flow?.signOut(context)
-      }
-    } else {
-      const authHandler = this.getAuthHandlerOrThrow(authHandlerId)
-      await authHandler.flow?.signOut(context)
+    if (authHandlerId?.trim()) {
+      const signInContext = this.createSignInContext(context, authHandlerId)
+      return signInContext?.signOut()
+    }
+
+    for (const id in this.authHandlers) {
+      const signInContext = this.createSignInContext(context, id)
+      await signInContext?.signOut()
     }
   }
-
-  /**
-   * Private handler for successful sign-in events.
-   * @private
-   */
-  _signInSuccessHandler: ((context: TurnContext, state: TurnState, authHandlerId?: string) => Promise<void>) | null = null
 
   /**
    * Sets a handler to be called when sign-in is successfully completed.
@@ -390,15 +342,9 @@ export class Authorization {
    *
    * @public
    */
-  public onSignInSuccess (handler: (context: TurnContext, state: TurnState, authHandlerId?: string) => Promise<void>) {
+  public onSignInSuccess (handler: (context: TurnContext, state: TurnState, authHandlerId?: string) => Promise<void> | void) {
     this._signInSuccessHandler = handler
   }
-
-  /**
-   * Private handler for failed sign-in events.
-   * @private
-   */
-  _signInFailureHandler: ((context: TurnContext, state: TurnState, authHandlerId?: string, errorMessage?: string) => Promise<void>) | null = null
 
   /**
    * Sets a handler to be called when sign-in fails.
@@ -426,7 +372,483 @@ export class Authorization {
    *
    * @public
    */
-  public onSignInFailure (handler: (context: TurnContext, state: TurnState, authHandlerId?: string, errorMessage?: string) => Promise<void>) {
+  public onSignInFailure (handler: (context: TurnContext, state: TurnState, authHandlerId?: string, errorMessage?: string) => Promise<void> | void) {
     this._signInFailureHandler = handler
+  }
+}
+
+class SignInStorage {
+  private _baseKey: string = ''
+  private _handlerKeys: string[] = []
+
+  /**
+   * Creates a new instance of SignInStorage.
+   *
+   * @param storage - The storage system to use for sign-in state management.
+   * @param handlers - Dictionary of configured authentication handlers.
+   * @throws {Error} If storage is null/undefined.
+   */
+  constructor (private storage: Storage, private handlers?: Record<string, AuthHandler>) {
+    if (!storage) {
+      throw new Error('Storage is required')
+    }
+  }
+
+  /**
+   * Creates a storage key for a specific sign-in handler.
+   *
+   * @param id - The ID of the sign-in handler.
+   * @returns The storage key for the sign-in handler.
+   * @throws {Error} If the base key is not set.
+   * @remarks
+   * This method generates a unique storage key for the specified sign-in handler by appending its ID to the base key.
+   */
+  private createKey (id: string): string {
+    if (!this._baseKey.trim()) {
+      throw new Error('Base key is not set, make sure to call setKey() first.')
+    }
+    return `${this._baseKey}/${id}`
+  }
+
+  /**
+   * Sets the base key for sign-in handler storage.
+   *
+   * @param context - The TurnContext for the current turn.
+   * @throws {Error} If 'channelId' or 'from.id' properties are not set in the activity.
+   * @remarks
+   * This method sets the base key for all sign-in handler states based on the channel and user ID.
+   * It is typically called at the beginning of a turn to ensure the correct context is used for storage.
+   */
+  setKey (context: TurnContext) {
+    const channelId = context.activity.channelId
+    const userId = context.activity.from?.id
+    if (!channelId || !userId) {
+      throw new Error('Activity \'channelId\' and \'from.id\' properties must be set.')
+    }
+    this._baseKey = `auth/${channelId}/${userId}`
+    this._handlerKeys = Object.keys(this.handlers ?? {}).map(e => this.createKey(e))
+  }
+
+  /**
+   * Retrieves the active sign-in handler state.
+   *
+   * @returns A promise that resolves to the active sign-in handler state, or undefined if not found.
+   * @remarks
+   * This method reads all sign-in handler states from storage and returns the first one that is not in 'success' status.
+   * It is typically used to check if there is an ongoing OAuth flow that needs to be continued.
+   */
+  async getActive (): Promise<SignInHandlerState | undefined> {
+    const data = await this.storage.read(this._handlerKeys) as Record<string, SignInHandlerState>
+    return Object.values(data).find(({ status }) => status !== 'success')
+  }
+
+  /**
+   * Retrieves a sign-in handler state by its ID.
+   *
+   * @param id - The ID of the sign-in handler to retrieve.
+   * @returns A promise that resolves to the sign-in handler state, or undefined if not found.
+   * @remarks
+   * This method reads the sign-in handler state from storage using the provided ID.
+   * It is typically used to load the current state of an ongoing OAuth flow.
+   */
+  async getOne (id: string): Promise<SignInHandlerState | undefined> {
+    const key = this.createKey(id)
+    const data = await this.storage.read([key]) as Record<string, SignInHandlerState>
+    return data[key]
+  }
+
+  /**
+   * Sets a sign-in handler state in storage.
+   *
+   * @param value - The sign-in handler state to set.
+   * @returns A promise that resolves when the state is set.
+   * @remarks
+   * This method writes the provided sign-in handler state to storage.
+   * It is typically used to save the current state of an ongoing OAuth flow.
+   */
+  async setOne (value: SignInHandlerState) {
+    return this.storage.write({ [this.createKey(value.id)]: value })
+  }
+
+  /**
+   * Deletes a sign-in handler state by its ID.
+   *
+   * @param id - The ID of the sign-in handler to delete.
+   * @returns A promise that resolves when the deletion is complete.
+   * @remarks
+   * This method removes the specified sign-in handler state from storage.
+   * It is typically used to clear the state after a successful sign-out or when the flow is no longer needed.
+   */
+  async deleteOne (id:string) {
+    return this.storage.delete([this.createKey(id)])
+  }
+}
+
+/**
+ * Context for managing sign-in operations.
+ * Handles the OAuth flow, token retrieval, and sign-out operations.
+ *
+ * @remarks
+ * The SignInContext class provides methods to manage the OAuth flow lifecycle,
+ * including starting, continuing, and completing the sign-in process.
+ * It also supports token exchange and sign-out operations.
+ *
+ * Key features:
+ * - Handles OAuth flow state management
+ * - Provides methods for token retrieval and exchange
+ * - Supports sign-out operations
+ * - Allows custom success/failure handlers
+ */
+class SignInContext {
+  private _onSuccessHandler: (() => Promise<void> | void) | undefined = undefined
+  private _onFailureHandler: ((err:string) => Promise<void> | void) | undefined = undefined
+  private _authHandler: AuthHandler = {}
+  private _handler: SignInHandlerState | undefined = undefined
+
+  /** Current sign-in handler state. */
+  get handler (): SignInHandlerState {
+    if (!this._handler) {
+      throw new Error('SignInContext handler is not initialized. Call loadHandler() first.')
+    }
+    return this._handler
+  }
+
+  /** Logger for the sign-in context, prepends handler ID to log messages. */
+  logger = {
+    info: (msg: string, ...args: any[]) => logger.info(`[handler:${this.handler.id}] ${msg}`, ...args),
+    warn: (msg: string, ...args: any[]) => logger.warn(`[handler:${this.handler.id}] ${msg}`, ...args),
+    error: (msg: string, ...args: any[]) => logger.error(`[handler:${this.handler.id}] ${msg}`, ...args),
+    debug: (msg: string, ...args: any[]) => logger.debug(`[handler:${this.handler.id}] ${msg}`, ...args)
+  }
+
+  /**
+   * Creates a new instance of SignInContext.
+   *
+   * @param storage - The storage system to use for sign-in state management.
+   * @param context - The TurnContext for the current turn.
+   * @param handlerId - ID of the auth handler to use.
+   * @param authHandler - The authentication handler to use for OAuth flows.
+   * @param useStorageState - Whether to use storage state for the sign-in handler.
+   */
+  constructor (public storage: SignInStorage, private authHandlers: AuthorizationHandlers, private context: TurnContext, private handlerId?: string, private useStorageState: boolean = true) {
+    if (!this.useStorageState && !this.handlerId) {
+      throw new Error('Cannot begin or continue OAuth flow without handlerId when useStorageState is false.')
+    }
+
+    if (this.useStorageState) {
+      this.storage.setKey(this.context)
+    }
+  }
+
+  /**
+   * Sets the handler to be called when sign-in is successful.
+   * @param handler - The handler function to call on sign-in success.
+   */
+  onSuccess (handler: SignInContext['_onSuccessHandler']) {
+    this._onSuccessHandler = handler
+  }
+
+  /**
+   * Sets the handler to be called when sign-in fails.
+   * @param handler - The handler function to call on sign-in failure.
+   */
+  onFailure (handler: SignInContext['_onFailureHandler']) {
+    this._onFailureHandler = handler
+  }
+
+  /**
+   * Retrieves the user token from the current sign-in handler.
+   * @returns A promise that resolves to the token response.
+   * @remarks
+   * This method loads the handler state and retrieves the user token from the OAuth flow.
+   * It is used to get the current user's authentication token after a successful sign-in.
+   */
+  async getUserToken (): Promise<TokenResponse> {
+    if (!(await this.loadHandler())) {
+      return { token: undefined }
+    }
+    this.logger.info('Getting token from user token service.')
+    return this._authHandler.flow!.getUserToken(this.context)
+  }
+
+  /**
+   * Exchanges the current user token for a new token with specified scopes.
+   * @param scopes - Array of scopes to request for the new token.
+   * @returns A promise that resolves to the exchanged token response.
+   * @remarks
+   * This method checks if the current token is exchangeable (e.g., has audience starting with 'api://')
+   * and performs the appropriate token exchange using MSAL.
+   */
+  async exchangeToken (scopes: string[]): Promise<TokenResponse> {
+    if (!(await this.loadHandler())) {
+      return { token: undefined }
+    }
+    this.logger.info('Exchanging token from user token service.')
+    const tokenResponse = await this._authHandler.flow!.getUserToken(this.context)
+    if (this.isExchangeable(tokenResponse.token)) {
+      return await this.handleObo(tokenResponse.token!, scopes)
+    }
+    return tokenResponse
+  }
+
+  /**
+   * Signs out the user from the current OAuth flow.
+   * @returns A promise that resolves when sign out is complete.
+   * @remarks
+   * This method clears the user's token and resets the authentication state.
+   * It also removes the handler state from storage if `useStorageState` is true.
+   */
+  async signOut (): Promise<void> {
+    if (!(await this.loadHandler())) {
+      return
+    }
+
+    this.logger.info('Signing out from the authorization flow.')
+    if (this.useStorageState) {
+      await this.storage.deleteOne(this.handler.id)
+    }
+    return this._authHandler.flow?.signOut(this.context)
+  }
+
+  /**
+   * Retrieves the token for the current sign-in handler.
+   * @returns {Promise<TokenResponse | undefined>} A promise that resolves to the token response if available, or undefined if not.
+   * @remarks
+   * This method processes the OAuth flow based on the current handler status:
+   * - If the status is 'begin', it starts a new OAuth flow.
+   * - If the status is 'continue', it continues the existing flow.
+   * - If the status is 'success', it retrieves the user token.
+   * - If the status is 'failure', it handles the failure case.
+   */
+  async getToken (): Promise<TokenResponse | undefined> {
+    if (!(await this.loadHandler())) {
+      return { token: undefined }
+    }
+
+    this.logger.debug('Processing authorization flow.')
+    this.logger.debug(`Uses Storage state: ${this.useStorageState}`)
+    this.logger.debug('Current sign-in state:', this.handler)
+
+    const tokenResponse: TokenResponse | undefined = await {
+      begin: this.begin,
+      continue: this.continue,
+      success: this.success,
+      failure: this.failure
+    }[this.handler.status].bind(this)()
+
+    this.logger.debug('OAuth flow result:', { token: tokenResponse?.token, state: this.handler })
+    return tokenResponse
+  }
+
+  /**
+   * Sets the current status of the sign-in handler.
+   * @param status - The new status to set.
+   * @returns The updated SignInHandlerState.
+   * @remarks
+   * This method updates the handler's state information based on the provided status.
+   * @private
+   */
+  private setStatus (status: SignInHandlerState['status']): SignInHandlerState {
+    const states: Record<SignInHandlerState['status'], () => SignInHandlerState> = {
+      begin: () => ({
+        id: this.handlerId ?? '',
+        status,
+      }),
+      continue: () => ({
+        ...this.handler,
+        status,
+        state: this._authHandler.flow?.state,
+        continuationActivity: this.context.activity
+      }),
+      success: () => ({
+        ...this.handler,
+        status,
+        state: undefined
+      }),
+      failure: () => ({
+        ...this.handler,
+        status,
+        state: this._authHandler.flow?.state
+      })
+    }
+    this._handler = states[status]()
+    return this.handler
+  }
+
+  /**
+   * Loads the current handler state from storage or initializes it.
+   * If the flow has already started and `useStorageState` is false, it uses the existing state.
+   * If no active flow state is found, it starts a new OAuth flow.
+   * @returns {Promise<void>} A promise that resolves when the handler is loaded.
+   * @private
+   */
+  private async loadHandler (): Promise<boolean> {
+    if (this.useStorageState) {
+      this._handler = this.handlerId ? await this.storage.getOne(this.handlerId) : await this.storage.getActive()
+    }
+
+    if (!this._handler) {
+      this._handler = this.setStatus('begin')
+    }
+
+    // If no active handler ID is set, cannot proceed.
+    if (!this.handler.id) {
+      return false
+    }
+
+    this._authHandler = this.getAuthHandlerOrThrow(this.handler.id)
+
+    if (!this.useStorageState && this._authHandler.flow?.state?.flowStarted === true) {
+      this.setStatus('success')
+      this.logger.debug('OAuth flow success, using existing state.')
+      return true
+    }
+
+    if (this.handler.status === 'begin') {
+      this.logger.debug('No active flow state, starting a new OAuth flow.')
+      await this._authHandler.flow?.signOut(this.context)
+    } else {
+      // Sync auth and active handler flow state.
+      // If there is not active handler state, reset.
+      await this._authHandler.flow?.setFlowState(this.context, this.handler.state ?? {} as FlowState)
+    }
+
+    return true
+  }
+
+  /**
+   * Begins the OAuth flow by starting the sign-in process.
+   * @returns {Promise<undefined>} A promise that resolves when the flow has started.
+   * @private
+   */
+  private async begin (): Promise<undefined> {
+    this.logger.debug('Beginning OAuth flow.')
+    await this._authHandler.flow?.beginFlow(this.context)
+    this.logger.debug('OAuth flow started, waiting on continuation ...')
+    this.setStatus('continue')
+    if (this.useStorageState) {
+      await this.storage.setOne(this.handler)
+    }
+  }
+
+  /**
+   * Continues the OAuth flow after user interaction.
+   * @returns {Promise<TokenResponse | undefined>} A promise that resolves to the token response if successful, or undefined if not.
+   * @private
+   */
+  private async continue (): Promise<TokenResponse | undefined> {
+    this.logger.debug('Continuing OAuth flow.')
+    const tokenResponse = await this._authHandler.flow?.continueFlow(this.context)
+    if (tokenResponse?.token?.trim()) {
+      this.setStatus('success')
+      this.logger.debug('OAuth flow success.')
+      if (this.useStorageState) {
+        await this.storage.setOne(this.handler)
+      }
+      if (this._onSuccessHandler) {
+        await this._onSuccessHandler()
+      }
+    } else {
+      await this.failure()
+    }
+
+    return tokenResponse
+  }
+
+  /**
+   * Retrieves the user token after a successful OAuth flow.
+   * @returns {Promise<TokenResponse | undefined>} A promise that resolves to the token response if successful, or undefined if not.
+   * @private
+   */
+  private async success (): Promise<TokenResponse | undefined> {
+    const tokenResponse = await this._authHandler.flow?.getUserToken(this.context)
+    if (this.useStorageState && tokenResponse?.token?.trim()) {
+      this.logger.debug('OAuth flow success, retrieving token.')
+      return tokenResponse
+    } else {
+      this.logger.debug('OAuth flow token not available, waiting on continuation ...')
+      return this.continue()
+    }
+  }
+
+  /**
+   * Handles the failure case of the OAuth flow.
+   * @returns {Promise<undefined>} A promise that resolves when the failure handling is complete.
+   * @private
+   */
+  private async failure (): Promise<undefined> {
+    this.setStatus('failure')
+
+    let errors = { reason: 'token was not received', reset: false }
+    if (!this.handler.continuationActivity) {
+      errors = { reason: 'no continuation activity available', reset: true }
+    } else if (this.handler.continuationActivity?.conversation?.id !== this.context.activity.conversation?.id) {
+      errors = { reason: 'conversation changed during the continuation flow', reset: true }
+    } else if (!this.handler.state?.flowStarted) {
+      errors = { reason: 'flow was restarted', reset: true }
+    }
+
+    const message = `Failed to complete OAuth flow due to ${errors.reason}.`
+    this.logger.warn(message)
+
+    if (errors.reset) {
+      await this._authHandler.flow?.signOut(this.context)
+      if (this.useStorageState) {
+        await this.storage.deleteOne(this.handler.id)
+      }
+    }
+
+    if (this._onFailureHandler) {
+      await this._onFailureHandler(message)
+    }
+  }
+
+  /**
+   * Checks if a token is exchangeable for an on-behalf-of flow.
+   *
+   * @param token - The token to check.
+   * @returns True if the token is exchangeable, false otherwise.
+   * @private
+   */
+  private isExchangeable (token: string | undefined): boolean {
+    if (!token || typeof token !== 'string') {
+      return false
+    }
+    const payload = jwt.decode(token) as JwtPayload
+    return payload?.aud?.indexOf('api://') === 0
+  }
+
+  /**
+   * Handles on-behalf-of token exchange using MSAL.
+   *
+   * @param context - The context object for the current turn.
+   * @param token - The token to exchange.
+   * @param scopes - Array of scopes to request for the new token.
+   * @returns A promise that resolves to the exchanged token response.
+   * @private
+   */
+  private async handleObo (token: string, scopes: string[]): Promise<TokenResponse> {
+    const msalTokenProvider = new MsalTokenProvider()
+    let authConfig: AuthConfiguration = this.context.adapter.authConfig
+    if (this._authHandler.cnxPrefix) {
+      authConfig = loadAuthConfigFromEnv(this._authHandler.cnxPrefix)
+    }
+    const newToken = await msalTokenProvider.acquireTokenOnBehalfOf(authConfig, scopes, token)
+    return { token: newToken }
+  }
+
+  /**
+   * Gets the auth handler by ID or throws an error if not found.
+   *
+   * @param handlerId - ID of the auth handler to retrieve.
+   * @returns The auth handler instance.
+   * @throws {Error} If the auth handler with the specified ID is not configured.
+   * @private
+   */
+  private getAuthHandlerOrThrow (handlerId: string): AuthHandler {
+    if (!Object.prototype.hasOwnProperty.call(this.authHandlers, handlerId)) {
+      throw new Error(`AuthHandler with ID ${handlerId} not configured`)
+    }
+    return this.authHandlers[handlerId]
   }
 }

--- a/packages/agents-hosting/src/oauth/oAuthFlow.ts
+++ b/packages/agents-hosting/src/oauth/oAuthFlow.ts
@@ -191,9 +191,10 @@ export class OAuthFlow {
     this.state = await this.getFlowState(context)
     await this.refreshToken(context)
     if (this.state?.flowExpires !== 0 && Date.now() > this.state?.flowExpires!) {
-      logger.warn('Flow expired')
+      logger.warn(`OAuth flow expired at ${new Date(this.state.flowExpires!).toISOString()}.`)
       await context.sendActivity(MessageFactory.text('Sign-in session expired. Please try again.'))
       this.state!.flowStarted = false
+      this.state!.flowExpires = 0
       return { token: undefined }
     }
     const contFlowActivity = context.activity

--- a/packages/agents-hosting/test/cases/authentication.md
+++ b/packages/agents-hosting/test/cases/authentication.md
@@ -14,11 +14,12 @@ This document presents a comprehensive suite of test cases for authentication ha
 
 - 🧑: User interaction
 - 🤖: Bot interaction
-- `oAuthCard`: ![oAuthCard](https://github.com/user-attachments/assets/5a5a124b-5247-4715-a9f6-2f750059a466)
 - `magic code`: 6-digit code gathered from the `oAuthCard`
 - `/me`: Login route for `graph` auth handler
 - `/status`: Login route for `graph` and `github` auth handlers
 - `/logout`: Logout route for `graph` and `github` auth handlers
+- `oAuthCard`: <br>
+  ![oAuthCard](https://github.com/user-attachments/assets/5a5a124b-5247-4715-a9f6-2f750059a466)
 
 ## Test Cases
 
@@ -109,7 +110,9 @@ User lets the flow expire, and then tries again, resulting in a session expired 
 2. 🤖 → Shows `oAuthCard`
 3. 🧑 → Waits for the flow to expire (or expires it manually from the Storage `flowExpires` property)
 4. 🧑 → Sends magic code
-5. 🤖 → Shows session expired message### 7. Invalid Magic Code with Expired Session
+5. 🤖 → Shows session expired message
+
+### 7. Invalid Magic Code with Expired Session
 
 **Description:**
 User enters an invalid magic code, lets the flow expire, and then tries again, resulting in a session expired message.

--- a/packages/agents-hosting/test/cases/authentication.md
+++ b/packages/agents-hosting/test/cases/authentication.md
@@ -1,0 +1,201 @@
+# Authentication Handler Test Scenarios
+
+This document presents a comprehensive suite of test cases for authentication handlers. The scenarios cover login, logout, multi-provider flows, and error handling, showing session management and user experience. All tests are compatible with a range of storage providers, including BlobStorage, CosmosDbPartitionedStorage, and FileStorage.
+
+## Requirements
+
+- [Dev Tunnels](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started?tabs=windows) for local development and testing
+- Storage providers: BlobStorage, CosmosDbPartitionedStorage, FileStorage, etc
+- Azure Bot OAuth connections:
+  - **Graph**: [Microsoft's AADv2 setup guide](https://github.com/microsoft/Agents/blob/main/docs/HowTo/azurebot-user-authentication-fic.md#register-the-oauth-identity-with-the-azure-bot)
+  - **GitHub**: Requires a GitHub account. In GitHub, go to Settings → Developer settings → OAuth apps, create a new OAuth app, and set the callback URL to `https://token.botframework.com/.auth/web/redirect`. In Azure Bot connection settings, provide the `clientId`, `clientSecret`, and required scopes: `user repo`.
+
+## Reference
+
+- 🧑: User interaction
+- 🤖: Bot interaction
+- `oAuthCard`: ![oAuthCard](https://github.com/user-attachments/assets/5a5a124b-5247-4715-a9f6-2f750059a466)
+- `magic code`: 6-digit code gathered from the `oAuthCard`
+- `/me`: Login route for `graph` auth handler
+- `/status`: Login route for `graph` and `github` auth handlers
+- `/logout`: Logout route for `graph` and `github` auth handlers
+
+## Test Cases
+
+> [!NOTE]
+> These test cases were created using the [autoAuth](/samples/auth/autoAuth.ts) sample.
+
+### 1. Normal Flow
+
+**Description:**
+User logs in to retrieve information from the Graph provider.
+
+**Steps:**
+
+1. 🧑 → Sends `/me` message
+2. 🤖 → Shows `oAuthCard`
+3. 🧑 → Clicks `oAuthCard` sign-in button
+4. 🧑 → Retrieves and sends `magic code`
+5. 🤖 → Shows signed-in user information from the Graph provider
+
+### 2. Reload Web Page or Restart Bot After Login
+
+**Description:**
+User reloads the web page or restarts the bot and checks if the session persists.
+
+**Steps:**
+
+1. 🧑 → Already logged in (see [Normal Flow](#1-normal-flow))
+2. 🧑 → Reloads web page or restarts bot
+3. 🧑 → Sends `/me` message
+4. 🤖 → Shows signed-in user information from the Graph provider
+
+### 3. Login, Restart Bot During Sign-In, and Logout
+
+**Description:**
+User logs in, restarts the bot during sign-in, and logs out to verify session handling.
+
+**Steps:**
+
+1. 🧑 → Sends `/me` message
+2. 🤖 → Shows `oAuthCard`
+3. 🧑 → Clicks `oAuthCard` sign-in button
+4. 🧑 → Retrieves `magic code`
+5. 🧑 → Restarts bot
+6. 🧑 → Sends `magic code`
+7. 🤖 → Shows signed-in user information from the Graph provider
+8. 🧑 → Sends `/me` message
+9. 🤖 → Shows signed-in user information from the Graph provider
+10. 🧑 → Sends `/logout` message
+11. 🤖 → Shows logged-out message
+
+### 4. Logout and Login
+
+**Description:**
+User logs out and then logs in again to confirm re-authentication works.
+
+**Steps:**
+
+1. 🧑 → Already logged in (see [Normal Flow](#1-normal-flow))
+2. 🧑 → Sends `/logout` message
+3. 🧑 → Sends `/me` message
+4. 🤖 → Shows `oAuthCard`
+5. 🧑 → Clicks `oAuthCard` sign-in button
+6. 🧑 → Retrieves and sends `magic code`
+7. 🤖 → Shows signed-in user information from the Graph provider
+
+### 5. Invalid Magic Code and Retry
+
+**Description:**
+User enters an invalid magic code, then retries with the correct code to complete sign-in.
+
+**Steps:**
+
+1. 🧑 → Sends `/me` message
+2. 🤖 → Shows `oAuthCard`
+3. 🧑 → Sends invalid magic code (e.g., `abc`)
+4. 🤖 → Shows invalid magic code format message
+5. 🧑 → Sends correct magic code
+6. 🤖 → Shows signed-in user information from the Graph provider
+
+### 6. Expired Session
+
+**Description:**
+User lets the flow expire, and then tries again, resulting in a session expired message.
+
+**Steps:**
+
+2. 🧑 → Sends `/me` message
+3. 🤖 → Shows `oAuthCard`
+6. 🧑 → Waits for the flow to expire (or expires it manually from the Storage `flowExpires` property)
+7. 🧑 → Sends magic code
+8. 🤖 → Shows session expired message
+
+### 7. Invalid Magic Code with Expired Session
+
+**Description:**
+User enters an invalid magic code, lets the flow expire, and then tries again, resulting in a session expired message.
+
+**Steps:**
+
+2. 🧑 → Sends `/me` message
+3. 🤖 → Shows `oAuthCard`
+4. 🧑 → Sends invalid magic code (e.g., `abc`)
+5. 🤖 → Shows invalid magic code format message
+6. 🧑 → Waits for the flow to expire (or expires it manually from the Storage `flowExpires` property)
+7. 🧑 → Sends magic code
+8. 🤖 → Shows session expired message
+
+### 8. Restart Conversation During Sign-In
+
+**Description:**
+User restarts the conversation during sign-in and receives appropriate flow and failure messages.
+
+**Steps:**
+
+1. 🧑 → Sends `/me` message
+2. 🤖 → Shows `oAuthCard`
+3. 🧑 → Restarts conversation
+4. 🤖 → Shows conversation changed during continuation flow message
+5. 🧑 → Sends `/me` message
+6. 🤖 → Shows `oAuthCard`
+
+### 9. Multi-Handler Login
+
+**Description:**
+User checks status and logs in to both handlers to verify multi-handler support.
+
+**Steps:**
+
+1. 🧑 → Sends `/status` message
+2. 🤖 → Shows `graph` `oAuthCard`
+3. 🧑 → Clicks `oAuthCard` sign-in button
+4. 🧑 → Retrieves and sends `magic code`
+5. 🤖 → Shows `github` `oAuthCard`
+6. 🧑 → Clicks `oAuthCard` sign-in button
+7. 🧑 → Retrieves and sends `magic code`
+8. 🤖 → Shows token status for both auth handlers
+
+### 10. Multi-Handler Logout and Login from One Auth Handler
+
+**Description:**
+User checks status, logs out of one handler, and logs in again to verify multi-handler support.
+
+**Steps:**
+
+1. 🧑 → Already logged in (see [Multi-Handler Login](#8-multi-handler-login))
+2. 🧑 → Sends `/logout github` message
+3. 🤖 → Shows `github` auth handler logged out message
+4. 🧑 → Sends `/status` message
+5. 🤖 → Shows `github` `oAuthCard`
+6. 🧑 → Retrieves and sends `magic code`
+7. 🤖 → Shows token status for both auth handlers
+
+### 11. Multi-Handler Logout and Login from All Auth Handlers
+
+**Description:**
+User logs out of all handlers and logs in again to both, confirming full session reset and re-authentication.
+
+**Steps:**
+
+1. 🧑 → Already logged in (see [Multi-Handler Login](#8-multi-handler-login))
+2. 🧑 → Sends `/logout` message
+3. 🤖 → Shows all handlers logged out message
+4. 🧑 → Logs in to both handlers again (see [Multi-Handler Login](#8-multi-handler-login))
+
+### 12. Multi-Server Instances
+
+**Description:**
+User simulates having multiple server instances by removing the handler from storage and verifies recovery by re-authenticating, validating that token memory is refreshed.
+
+**Steps:**
+
+1. 🧑 → Sends `/me` message
+2. 🤖 → Shows `oAuthCard`
+3. 🧑 → Retrieves and sends `magic code`
+4. 🤖 → Shows signed-in user information from the Graph provider
+5. 🧑 → Removes handler from storage (simulates wrong memory flow)
+6. 🧑 → Sends `/me` message
+7. 🤖 → Shows `oAuthCard`
+8. 🧑 → Retrieves and sends `magic code`
+9. 🤖 → Shows signed-in user information from the Graph provider

--- a/packages/agents-hosting/test/cases/authentication.md
+++ b/packages/agents-hosting/test/cases/authentication.md
@@ -105,26 +105,24 @@ User lets the flow expire, and then tries again, resulting in a session expired 
 
 **Steps:**
 
-2. 🧑 → Sends `/me` message
-3. 🤖 → Shows `oAuthCard`
-6. 🧑 → Waits for the flow to expire (or expires it manually from the Storage `flowExpires` property)
-7. 🧑 → Sends magic code
-8. 🤖 → Shows session expired message
-
-### 7. Invalid Magic Code with Expired Session
+1. 🧑 → Sends `/me` message
+2. 🤖 → Shows `oAuthCard`
+3. 🧑 → Waits for the flow to expire (or expires it manually from the Storage `flowExpires` property)
+4. 🧑 → Sends magic code
+5. 🤖 → Shows session expired message### 7. Invalid Magic Code with Expired Session
 
 **Description:**
 User enters an invalid magic code, lets the flow expire, and then tries again, resulting in a session expired message.
 
 **Steps:**
 
-2. 🧑 → Sends `/me` message
-3. 🤖 → Shows `oAuthCard`
-4. 🧑 → Sends invalid magic code (e.g., `abc`)
-5. 🤖 → Shows invalid magic code format message
-6. 🧑 → Waits for the flow to expire (or expires it manually from the Storage `flowExpires` property)
-7. 🧑 → Sends magic code
-8. 🤖 → Shows session expired message
+1. 🧑 → Sends `/me` message
+2. 🤖 → Shows `oAuthCard`
+3. 🧑 → Sends invalid magic code (e.g., `abc`)
+4. 🤖 → Shows invalid magic code format message
+5. 🧑 → Waits for the flow to expire (or expires it manually from the Storage `flowExpires` property)
+6. 🧑 → Sends magic code
+7. 🤖 → Shows session expired message
 
 ### 8. Restart Conversation During Sign-In
 
@@ -163,7 +161,7 @@ User checks status, logs out of one handler, and logs in again to verify multi-h
 
 **Steps:**
 
-1. 🧑 → Already logged in (see [Multi-Handler Login](#8-multi-handler-login))
+1. 🧑 → Already logged in (see [Multi-Handler Login](#9-multi-handler-login))
 2. 🧑 → Sends `/logout github` message
 3. 🤖 → Shows `github` auth handler logged out message
 4. 🧑 → Sends `/status` message
@@ -178,10 +176,10 @@ User logs out of all handlers and logs in again to both, confirming full session
 
 **Steps:**
 
-1. 🧑 → Already logged in (see [Multi-Handler Login](#8-multi-handler-login))
+1. 🧑 → Already logged in (see [Multi-Handler Login](#9-multi-handler-login))
 2. 🧑 → Sends `/logout` message
 3. 🤖 → Shows all handlers logged out message
-4. 🧑 → Logs in to both handlers again (see [Multi-Handler Login](#8-multi-handler-login))
+4. 🧑 → Logs in to both handlers again (see [Multi-Handler Login](#9-multi-handler-login))
 
 ### 12. Multi-Server Instances
 

--- a/samples/auth/autoAuth.ts
+++ b/samples/auth/autoAuth.ts
@@ -39,7 +39,7 @@ class OneProvider extends AgentApplication<TurnState> {
   private _logout = async (context: TurnContext, state: TurnState): Promise<void> => {
     // /logout <github|graph> (e.g. /logout github) to log out from a specific handler.
     // /logout (e.g. /logout) to log out from all handlers.
-    const handlerId = context.activity.text?.split(/\s/)?.[1]?.trim()
+    const handlerId = context.activity.text?.split(' ', 2)?.[1]?.trim()
     await this.authorization.signOut(context, state, handlerId)
     if (handlerId) {
       await context.sendActivity(MessageFactory.text(`User logged out from '${handlerId}' handler`))


### PR DESCRIPTION
Fixes #466
Fixes #464

## Description
This PR refactors the Authorization class to handle its own storage state to avoid inconsistencies with the oAuthFlow class keeping the auth flow and token in memory.
The new Authorization state will mainly handle 4 status: `begin, continue, success, and failure`. In each state, a different operation will be performed.
The purpose of these 4 type of state statuses is to track the ongoing authorization per handler and resume the flow in case of using multiple server instances, loss of connection, bot restart, etc.
Moreover, the Authorization class creates a SignInContext per auth handler (`graph`, `github`, etc.) to maintain the state for each handler separately, and when saved into the storage (e.g. Blobs) each context will have its own separated blob, associated with the Channel+User+Handler.

> [!NOTE]
> The `runInternal` method will ignore Typing activities as the authentication process should only be executed in non-typing scenarios, as it will cause unwanted behaviors when typing the magic code. 

## Testing
We added an `authentication.md` file with all the test cases we performed.

The following image shows some of the cases we tested.
<img width="1287" height="1179" alt="image" src="https://github.com/user-attachments/assets/fa93c929-5689-4af6-a56a-33b4b1e44993" />
<img width="1398" height="1193" alt="image" src="https://github.com/user-attachments/assets/68777b6e-d252-4cbc-a350-e7c3c71913fe" />
<img width="1779" height="1129" alt="image" src="https://github.com/user-attachments/assets/1c615b0d-2429-4858-bfb6-340aa46c55fa" />