### PR TITLE
[#367] Review usage of Revocable proxies

### DIFF
--- a/packages/agents-hosting/src/baseAdapter.ts
+++ b/packages/agents-hosting/src/baseAdapter.ts
@@ -169,6 +169,17 @@ export abstract class BaseAdapter {
     return this
   }
 
+  /**
+   * This method creates a revocable proxy for the given target object.
+   * If the environment does not support Proxy.revocable, it returns the original object.
+   * @remarks
+   * This is used to enhance security by allowing the proxy to be revoked after use,
+   * preventing further access to the underlying object.
+   *
+   * @param target The target object to be proxied.
+   * @param handler Optional proxy handler to customize behavior.
+   * @returns An object containing the proxy and a revoke function.
+   */
   private makeRevocable<T extends Record<string, any>>(
     target: T,
     handler?: ProxyHandler<T>
@@ -200,6 +211,7 @@ export abstract class BaseAdapter {
       context.locale = context.activity.locale
     }
 
+    // Create a revocable proxy for the context which will automatically be revoked upon completion of the turn.
     const pContext = this.makeRevocable(context)
 
     try {
@@ -216,6 +228,8 @@ export abstract class BaseAdapter {
       }
     } finally {
       pContext.revoke()
+      // Accessing the context after this point, will throw a TypeError.
+      // e.g.: "TypeError: Cannot perform 'get' on a proxy that has been revoked"
     }
   }
 }


### PR DESCRIPTION
Fixes #367

## Description
This PR documents the use of `Proxy.revocable` in the **_BaseAdapter's runMiddleware_** function.
This mechanism enhances security by ensuring that once the proxy is revoked, after the middleware pipeline completes or errors,  any access attempt to the TurnContext will throw an error.

## Detailed Changes
- Added documentation to the _makeRevocable_ function and its use in **_BaseAdapter_**.

## Testing
This image shows how the documentation is displayed.
<img width="1415" height="557" alt="image" src="https://github.com/user-attachments/assets/0498f0d0-bc5e-460e-9cdb-6866ccf6fc34" />