### PR TITLE
[#524] Review processing order of FileDownloaders in AgentApplication

### DIFF
--- a/packages/agents-hosting/src/app/agentApplication.ts
+++ b/packages/agents-hosting/src/app/agentApplication.ts
@@ -571,8 +571,8 @@ export class AgentApplication<TState extends TurnState> {
    * 2. Processes mentions if configured
    * 3. Loads turn state
    * 4. Handles authentication flows
-   * 5. Executes before-turn event handlers
-   * 6. Downloads files if file downloaders are configured
+   * 5. Downloads files if file downloaders are configured
+   * 6. Executes before-turn event handlers
    * 7. Routes to appropriate handlers
    * 8. Executes after-turn event handlers
    * 9. Saves turn state
@@ -625,15 +625,15 @@ export class AgentApplication<TState extends TurnState> {
           // return true
         }
 
-        if (!(await this.callEventHandlers(context, state, this._beforeTurn))) {
-          await state.save(context, storage)
-          return false
-        }
-
         if (Array.isArray(this._options.fileDownloaders) && this._options.fileDownloaders.length > 0) {
           for (let i = 0; i < this._options.fileDownloaders.length; i++) {
             await this._options.fileDownloaders[i].downloadAndStoreFiles(context, state)
           }
+        }
+
+        if (!(await this.callEventHandlers(context, state, this._beforeTurn))) {
+          await state.save(context, storage)
+          return false
         }
 
         for (const route of this._routes) {


### PR DESCRIPTION
Fixes #524

## Description
This PR reorganizes the logic within the **_runInternal_** method of **_AgentApplication_** to ensure that the _fileDownloaders_ are executed prior to calling any _BeforeTurn_ handlers. 
This allows common file processing to occur for all routes and channels once the files have been downloaded.

### Detailed Changes
- Updated **agentApplication** _runInternal_ method moving the call to _beforeTurn_ handlers after the execution of the _fileDownloaders_.

## Testing
To test these changes, we updated the **_samples/basic/attachments_** file adding the following handler:
```TypeScript
agent.onTurn('beforeTurn', async (context, state) => {
  if (context.activity.type === ActivityTypes.Typing) {
    return true
  }
  const files = (state.getValue(storedFilesKey) as unknown[] | undefined) ?? []
  await context.sendActivity(`BeforeTurn: Processing ${files.length} files...`)
  return true
})
```

These images show the sample working before and after the changes.
<img width="1342" height="897" alt="image" src="https://github.com/user-attachments/assets/8b09edcc-4103-4a6a-a4ee-c70d7d74e7b9" />
