### PR TITLE
fix: Apply default values to custom AuthConfiguration in CloudAdapter

### DIFF
--- a/packages/agents-hosting/src/auth/authConfiguration.ts
+++ b/packages/agents-hosting/src/auth/authConfiguration.ts
@@ -35,7 +35,7 @@ export interface AuthConfiguration {
   /**
    * A list of valid issuers for the authentication configuration.
    */
-  issuers: string[]
+  issuers?: string[]
 
   /**
    * The connection name for the authentication configuration.
@@ -56,6 +56,47 @@ export interface AuthConfiguration {
    * see also https://learn.microsoft.com/entra/identity-platform/authentication-national-cloud
    */
   authority?: string
+}
+
+/**
+ * Applies default values to a partial AuthConfiguration object.
+ *
+ * @param config - The authentication configuration to apply defaults to
+ * @returns The authentication configuration with defaults applied.
+ * @throws Will throw an error if clientId is not provided in production.
+ *
+ * @remarks
+ * This function ensures that all required fields have appropriate default values,
+ * including authority endpoint, issuers array, and validates clientId in production environments.
+ * It applies the same default logic as `loadAuthConfigFromEnv`.
+ *
+ * @example
+ * ```
+ * const customConfig = {
+ *   clientId: 'your-client-id',
+ *   clientSecret: 'your-client-secret',
+ *   tenantId: 'your-tenant-id'
+ * }
+ * 
+ * const configWithDefaults = applyAuthConfigDefaults(customConfig)
+ * // configWithDefaults.authority will be 'https://login.microsoftonline.com'
+ * // configWithDefaults.issuers will contain the standard issuers array
+ * ```
+ */
+export const applyAuthConfigDefaults = (config: AuthConfiguration): AuthConfiguration => {
+  const authority = config.authority ?? 'https://login.microsoftonline.com'
+  if (config.clientId === undefined && process.env.NODE_ENV === 'production') {
+    throw new Error('ClientId required in production')
+  }
+  return {
+    ...config,
+    authority,
+    issuers: config.issuers ?? [
+      'https://api.botframework.com',
+      `https://sts.windows.net/${config.tenantId}/`,
+      `${authority}/${config.tenantId}/v2.0`
+    ]
+  }
 }
 
 /**

--- a/packages/agents-hosting/src/cloudAdapter.ts
+++ b/packages/agents-hosting/src/cloudAdapter.ts
@@ -9,7 +9,7 @@ import { TurnContext } from './turnContext'
 import { Response } from 'express'
 import { Request } from './auth/request'
 import { ConnectorClient } from './connector-client/connectorClient'
-import { AuthConfiguration, loadAuthConfigFromEnv } from './auth/authConfiguration'
+import { AuthConfiguration, loadAuthConfigFromEnv, applyAuthConfigDefaults } from './auth/authConfiguration'
 import { AuthProvider } from './auth/authProvider'
 import { Activity, ActivityEventNames, ActivityTypes, Channels, ConversationReference, DeliveryModes, ConversationParameters } from '@microsoft/agents-activity'
 import { ResourceResponse } from './connector-client/resourceResponse'
@@ -48,7 +48,7 @@ export class CloudAdapter extends BaseAdapter {
    */
   constructor (authConfig?: AuthConfiguration, authProvider?: AuthProvider, userTokenClient?: UserTokenClient) {
     super()
-    this.authConfig = authConfig ?? loadAuthConfigFromEnv()
+    this.authConfig = authConfig ? applyAuthConfigDefaults(authConfig) : loadAuthConfigFromEnv()
     this.authProvider = authProvider ?? new MsalTokenProvider()
     this.userTokenClient = userTokenClient ?? new UserTokenClient(this.authConfig.clientId)
   }


### PR DESCRIPTION
## Description
This PR fixes an issue where the `authority` field is not properly populated when a custom `AuthConfiguration` is provided to `CloudAdapter`, despite this field being marked as optional in the TypeScript interface.

### Problem
When creating a `CloudAdapter` with a custom authentication configuration, the optional `authority` field was not receiving its default value. This caused runtime errors in `MsalTokenProvider` methods that expect `authority` to be defined, even though TypeScript types suggest it's optional.

### Error Example
```typescript
// This code would fail at runtime
const customConfig: AuthConfiguration = {
  clientId: 'my-client-id',
  clientSecret: 'my-secret',
  tenantId: 'my-tenant-id'
  // authority is optional in TypeScript, but missing it causes runtime error
};

const adapter = new CloudAdapter(customConfig);
```

When adapter tries to acquire token, it fails with:

```
ClientConfigurationError: url_parse_error: URL could not be parsed into appropriate segments.
     at createClientConfigurationError (/demo-app/node_modules/@azure/msal-common/dist/error/ClientConfigurationError.mjs:146:12)
     at UrlString.validateAsUri (/demo-app/node_modules/@azure/msal-common/dist/url/UrlString.mjs:64:19)
     at Authority.set canonicalAuthority (/demo-app/node_modules/@azure/msal-common/dist/authority/Authority.mjs:97:34)
     at new Authority (/demo-app/node_modules/@azure/msal-common/dist/authority/Authority.mjs:33:32)
     at AuthorityFactory.createDiscoveredInstance (/demo-app/node_modules/@azure/msal-common/dist/authority/AuthorityFactory.mjs:28:35)
     at ConfidentialClientApplication.createAuthority (/demo-app/node_modules/@azure/src/client/ClientApplication.ts:667:16)
     at ConfidentialClientApplication.acquireTokenByClientCredential (/demo-app/node_modules/@azure/src/client/ConfidentialClientApplication.ts:224:52)
     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
     at async MsalTokenProvider.acquireAccessTokenViaSecret (/demo-app/node_modules/@microsoft/agents-hosting/src/auth/msalTokenProvider.ts:172:16)
     at async MsalTokenProvider.getAccessToken (/demo-app/node_modules/@microsoft/agents-hosting/src/auth/msalTokenProvider.ts:36:15)
```

### Solution
Implemented a new helper function `applyAuthConfigDefaults()` that automatically applies default values to any `AuthConfiguration` object, ensuring consistency between custom configs and those loaded from environment variables.

The `CloudAdapter` constructor now uses this helper to apply defaults when a custom `authConfig` is provided, ensuring that `authority` and other optional fields receive their appropriate default values. This maintains backward compatibility while preventing runtime errors.