### PR TITLE
Remove Service Principal login instructions from README

### DIFF
--- a/test-agents/copilotstudio-console/README.md
+++ b/test-agents/copilotstudio-console/README.md
@@ -56,42 +56,6 @@ This step will require permissions to Create application identities in your Azur
     - `tenantId`: The App Registration Directory (tenant) ID.
     - `appClientId`: The App Registration Application (client) ID.
 
-### Create an Application Registration in Entra ID - Service Principal Login
-
-> [!Warning]
-> The Service Principal login method is not generally supported in the current version of the CopilotStudioClient. 
-> 
-> Current use of this feature requires authorization from Copilot Studio team and will be made generally available in the future.
-
-> [!IMPORTANT]
-> When using Service Principal login, Your Copilot Studio Agent must be configured for User Anonymous authentication. Settings => Security => Authentication => No authentication.
-
-This step will require permissions to Create application identities in your Azure tenant. For this sample, you will be creating a Native Client Application Identity.
-
-1. Open https://portal.azure.com 
-1. Navigate to Entra Id
-1. Create an new App Registration in Entra ID 
-    1. Provide an Name
-    1. Choose "Accounts in this organization directory only"
-    1. Then click register.
-1. In your newly created application
-    1. On the Overview page, Note down for use later when configuring the example application:
-        1. the Application (client) ID
-        1. the Directory (tenant) ID
-    1. Go to Manage
-    1. Go to API Permissions
-    1. Click Add Permission
-        1. In the side panel that appears, Click the tab `APIs my organization uses`
-        1. Search for `Power Platform API`.
-            1. *If you do not see `Power Platform API` see the note at the bottom of this section.*
-        1. In the permissions list choose `Application Permissions`, then `CopilotStudio` and check `CopilotStudio.Copilots.Invoke`
-        1. Click `Add Permissions`
-    1. Click `Grant Admin consent for copilotsdk`
-    1. Close Azure Portal
-
-> [!TIP]
-> If you do not see `Power Platform API` in the list of API's your organization uses, you need to add the Power Platform API to your tenant. To do that, goto [Power Platform API Authentication](https://learn.microsoft.com/power-platform/admin/programmability-authentication-v2#step-2-configure-api-permissions) and follow the instructions on Step 2 to add the Power Platform Admin API to your Tenant
-
 #### Instructions - Configure the Example Application
 
 1. Open the [env.TEMPLATE](./copilotstudio/env.TEMPLATE) and rename it to .env.


### PR DESCRIPTION
Removed instructions for creating an Application Registration in Entra ID, including warnings and steps for Service Principal login.