### PR TITLE
Use AsyncIterator in copilotStudioClient stream responses

### DIFF
--- a/compat/baseline/agents-copilotstudio-client.api.md
+++ b/compat/baseline/agents-copilotstudio-client.api.md
@@ -25,10 +25,10 @@ export class ConnectionSettings extends ConnectionOptions {
 // @public
 export class CopilotStudioClient {
     constructor(settings: ConnectionSettings, token: string);
-    askQuestionAsync(question: string, conversationId?: string): Promise<Activity[]>;
+    askQuestionAsync(question: string, conversationId?: string): AsyncGenerator<Activity>;
     static scopeFromSettings: (settings: ConnectionSettings) => string;
-    sendActivity(activity: Activity, conversationId?: string): Promise<Activity[]>;
-    startConversationAsync(emitStartConversationEvent?: boolean): Promise<Activity>;
+    sendActivity(activity: Activity, conversationId?: string): AsyncGenerator<Activity>;
+    startConversationAsync(emitStartConversationEvent?: boolean): AsyncGenerator<Activity>;
 }
 
 // @public

--- a/packages/agents-copilotstudio-client/src/copilotStudioWebChat.ts
+++ b/packages/agents-copilotstudio-client/src/copilotStudioWebChat.ts
@@ -218,12 +218,13 @@ export class CopilotStudioWebChat {
 
       logger.debug('--> Connection established.')
       notifyTyping()
-      const activity = await client.startConversationAsync()
-      // Remove replyToId to avoid timeout issues with WebChat on first activity.
-      delete activity.replyToId
-      conversation = activity.conversation
-      sequence = 0
-      notifyActivity(activity)
+
+      for await (const activity of client.startConversationAsync()) {
+        delete activity.replyToId
+        conversation = activity.conversation
+        sequence = 0
+        notifyActivity(activity)
+      }
     })
 
     const notifyActivity = (activity: Partial<Activity>) => {
@@ -276,9 +277,7 @@ export class CopilotStudioWebChat {
             notifyActivity(newActivity)
             notifyTyping()
 
-            const activities = await client.sendActivity(newActivity)
-
-            for (const responseActivity of activities) {
+            for await (const responseActivity of client.sendActivity(newActivity)) {
               notifyActivity(responseActivity)
             }
 

--- a/packages/agents-copilotstudio-client/src/copilotStudioWebChat.ts
+++ b/packages/agents-copilotstudio-client/src/copilotStudioWebChat.ts
@@ -222,7 +222,6 @@ export class CopilotStudioWebChat {
       for await (const activity of client.startConversationAsync()) {
         delete activity.replyToId
         conversation = activity.conversation
-        sequence = 0
         notifyActivity(activity)
       }
     })

--- a/samples/mcs/mcsAgent.ts
+++ b/samples/mcs/mcsAgent.ts
@@ -51,14 +51,14 @@ class McsAgent extends AgentApplication<TurnState> {
     const cpsClient = this.createClient(oboToken.token!)
 
     if (cid === undefined || cid === null || cid.length === 0) {
-      const newAct = await cpsClient.startConversationAsync()
-      if (newAct.type === ActivityTypes.Message) {
-        await context.sendActivity(newAct.text!)
-        state.setValue('conversation.conversationId', newAct.conversation!.id)
+      for await (const activity of cpsClient.startConversationAsync()) {
+        if (activity.type === ActivityTypes.Message) {
+          await context.sendActivity(activity.text!)
+          state.setValue('conversation.conversationId', activity.conversation!.id)
+        }
       }
     } else {
-      const resp = await cpsClient!.askQuestionAsync(context.activity.text!, cid)
-      for await (const activity of resp) {
+      for await (const activity of cpsClient!.askQuestionAsync(context.activity.text!, cid)) {
         console.log('Received activity:', activity.type, activity.text)
         if (activity.type === 'message') {
           await context.sendActivity(activity)

--- a/test-agents/copilotstudio-console/src/index.ts
+++ b/test-agents/copilotstudio-console/src/index.ts
@@ -112,7 +112,7 @@ const askQuestion = async (copilotClient: CopilotStudioClient, conversationId: s
       rl.close()
       return
     } else if (answer.length > 0) {
-      for await (const replyActivity of await copilotClient.askQuestionAsync(answer, conversationId)) {
+      for await (const replyActivity of copilotClient.askQuestionAsync(answer, conversationId)) {
         if (replyActivity.type === ActivityTypes.Message) {
           console.log(`\n${replyActivity.text}`)
           replyActivity.suggestedActions?.actions.forEach((action: CardAction) => console.log(action.value))


### PR DESCRIPTION
Fixes # 595

## Description
This PR updates the Copilot Studio Client package to use AsyncIterators and return the Agent's messages as they arrive rather than waiting for the entire response.


>**NOTE:**
These changes **break compatibility** for customers using the startConversationAsync and askQuestionAsync methods directly, not for those using the copilotStudioWebChat createConnection method.

### Detailed Changes
- In **_copilotStudioClient_**:
   - Updated the _postRequestAsync_ method to yield each Agent's response until the connection is closed. 
   - Updated the _startConversationAsync_, _askQuestionAsync_, and _SendActivity_ methods to handle the _AsyncIterator_ containing the Agent's responses.
- In **_copilotStudioWebChat_**:
   - Updated the _createConnection_ method to handle the agent's async responses with `for await`.
- Updated **_copilotstudio-console_** test-agent and **_mcsAgent_** sample to handle the agent's async responses with `for await`.
- Updated method signatures in _**agents-copilotstudio-client.api.md**_

## Testing
These images show the samples working after the changes.
<img width="1411" height="783" alt="image" src="https://github.com/user-attachments/assets/85f6bbea-f5a7-454a-ac12-0342eef8a4e1" />