### PR TITLE
Implement Event-Source Send in CopilotStudioClient to handle stream responses

### DIFF
--- a/compat/baseline/agents-copilotstudio-client.api.md
+++ b/compat/baseline/agents-copilotstudio-client.api.md
@@ -25,10 +25,10 @@ export class ConnectionSettings extends ConnectionOptions {
 // @public
 export class CopilotStudioClient {
     constructor(settings: ConnectionSettings, token: string);
-    askQuestionAsync(question: string, conversationId?: string): Promise<Activity[]>;
+    askQuestionAsync(question: string, conversationId?: string): AsyncGenerator<Activity>;
     static scopeFromSettings: (settings: ConnectionSettings) => string;
-    sendActivity(activity: Activity, conversationId?: string): Promise<Activity[]>;
-    startConversationAsync(emitStartConversationEvent?: boolean): Promise<Activity>;
+    sendActivity(activity: Activity, conversationId?: string): AsyncGenerator<Activity>;
+    startConversationAsync(emitStartConversationEvent?: boolean): AsyncGenerator<Activity>;
 }
 
 // @public

--- a/package-lock.json
+++ b/package-lock.json
@@ -3617,6 +3617,27 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource-client": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eventsource-client/-/eventsource-client-1.2.0.tgz",
+      "integrity": "sha512-kDI75RSzO3TwyG/K9w1ap8XwqSPcwi6jaMkNulfVeZmSeUM49U8kUzk1s+vKNt0tGrXgK47i+620Yasn1ccFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "5.1.0",
       "license": "MIT",
@@ -7105,7 +7126,7 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/agents-activity": "file:../agents-activity",
-        "axios": "^1.12.2",
+        "eventsource-client": "^1.2.0",
         "rxjs": "7.8.2",
         "uuid": "^11.1.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3619,8 +3619,6 @@
     },
     "node_modules/eventsource-client": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eventsource-client/-/eventsource-client-1.2.0.tgz",
-      "integrity": "sha512-kDI75RSzO3TwyG/K9w1ap8XwqSPcwi6jaMkNulfVeZmSeUM49U8kUzk1s+vKNt0tGrXgK47i+620Yasn1ccFiw==",
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.0"
@@ -3631,8 +3629,6 @@
     },
     "node_modules/eventsource-parser": {
       "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/packages/agents-copilotstudio-client/package.json
+++ b/packages/agents-copilotstudio-client/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@microsoft/agents-activity": "file:../agents-activity",
-    "axios": "^1.12.2",
+    "eventsource-client": "^1.2.0",
     "rxjs": "7.8.2",
     "uuid": "^11.1.0"
   },

--- a/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
+++ b/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
@@ -58,7 +58,6 @@ export class CopilotStudioClient {
    */
   private async * postRequestAsync (url: string, body?: any, method: string = 'POST'): AsyncGenerator<Activity> {
     logger.debug(`>>> SEND TO ${url}`)
-    let responseHeaders: Headers | undefined
 
     const eventSource: EventSourceClient = createEventSource({
       url,

--- a/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
+++ b/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { createEventSource, EventSourceClient } from 'eventsource-client'
 import { ConnectionSettings } from './connectionSettings'
-import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
 import { getCopilotStudioConnectionUrl, getTokenAudience } from './powerPlatformEnvironment'
 import { Activity, ActivityTypes, ConversationAccount } from '@microsoft/agents-activity'
 import { ExecuteTurnRequest } from './executeTurnRequest'
@@ -13,11 +13,6 @@ import { version } from '../package.json'
 import os from 'os'
 
 const logger = debug('copilot-studio:client')
-
-interface streamRead {
-  done: boolean,
-  value: string
-}
 
 /**
  * Client for interacting with Microsoft Copilot Studio services.
@@ -33,8 +28,8 @@ export class CopilotStudioClient {
   private conversationId: string = ''
   /** The connection settings for the client. */
   private readonly settings: ConnectionSettings
-  /** The Axios instance used for HTTP requests. */
-  private readonly client: AxiosInstance
+  /** The authenticaton token. */
+  private readonly token: string
 
   /**
    * Returns the scope URL needed to connect to Copilot Studio from the connection settings.
@@ -51,79 +46,69 @@ export class CopilotStudioClient {
    */
   constructor (settings: ConnectionSettings, token: string) {
     this.settings = settings
-    this.client = axios.create()
-    this.client.defaults.headers.common.Authorization = `Bearer ${token}`
-    this.client.defaults.headers.common['User-Agent'] = CopilotStudioClient.getProductInfo()
+    this.token = token
   }
 
-  private async postRequestAsync (axiosConfig: AxiosRequestConfig): Promise<Activity[]> {
-    const activities: Activity[] = []
+  /**
+   * Streams activities from the Copilot Studio service using eventsource-client.
+   * @param url The connection URL for Copilot Studio.
+   * @param body Optional. The request body (for POST).
+   * @param method Optional. The HTTP method (default: POST).
+   * @returns An async generator yielding the Agent's Activities.
+   */
+  private async * postRequestAsync (url: string, body?: any, method: string = 'POST'): AsyncGenerator<Activity> {
+    logger.debug(`>>> SEND TO ${url}`)
+    let responseHeaders: Headers | undefined
 
-    logger.debug(`>>> SEND TO ${axiosConfig.url}`)
-
-    const response = await this.client(axiosConfig)
-
-    if (this.settings.useExperimentalEndpoint && !this.settings.directConnectUrl?.trim()) {
-      const islandExperimentalUrl = response.headers?.[CopilotStudioClient.islandExperimentalUrlHeaderKey]
-      if (islandExperimentalUrl) {
-        this.settings.directConnectUrl = islandExperimentalUrl
-        logger.debug(`Island Experimental URL: ${islandExperimentalUrl}`)
+    const eventSource: EventSourceClient = createEventSource({
+      url,
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        'User-Agent': CopilotStudioClient.getProductInfo(),
+        'Content-Type': 'application/json',
+        Accept: 'text/event-stream'
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      method,
+      fetch: async (url, init) => {
+        const response = await fetch(url, init)
+        this.processResponseHeaders(response.headers)
+        return response
       }
-    }
-
-    this.conversationId = response.headers?.[CopilotStudioClient.conversationIdHeaderKey] ?? ''
-    if (this.conversationId) {
-      logger.debug(`Conversation ID: ${this.conversationId}`)
-    }
-
-    const sanitizedHeaders = { ...response.headers }
-    delete sanitizedHeaders['Authorization']
-    delete sanitizedHeaders[CopilotStudioClient.conversationIdHeaderKey]
-    logger.debug('Headers received:', sanitizedHeaders)
-
-    const stream = response.data
-    const reader = stream.pipeThrough(new TextDecoderStream()).getReader()
-    let result: string = ''
-    const results: string[] = []
-
-    const processEvents = async ({ done, value }: streamRead): Promise<string[]> => {
-      if (done) {
-        logger.debug('Stream complete')
-        result += value
-        results.push(result)
-        return results
-      }
-      logger.info('Agent is typing ...')
-      result += value
-
-      return await processEvents(await reader.read())
-    }
-
-    const events: string[] = await reader.read().then(processEvents)
-
-    events.forEach(event => {
-      const values: string[] = event.toString().split('\n')
-      const validEvents = values.filter(e => e.substring(0, 4) === 'data' && e !== 'data: end\r')
-      validEvents.forEach(ve => {
-        try {
-          const act = Activity.fromJson(ve.substring(5, ve.length))
-          if (act.type === ActivityTypes.Message) {
-            activities.push(act)
-            if (!this.conversationId.trim()) {
-              // Did not get it from the header.
-              this.conversationId = act.conversation?.id ?? ''
-              logger.debug(`Conversation ID: ${this.conversationId}`)
-            }
-          } else {
-            logger.debug(`Activity type: ${act.type}`)
-          }
-        } catch (e) {
-          logger.error('Error: ', e)
-          throw e
-        }
-      })
     })
-    return activities
+
+    for await (const { data, event } of eventSource) {
+      if (data && event === 'activity') {
+        try {
+          const activity = Activity.fromJson(data)
+          switch (activity.type) {
+            case ActivityTypes.Message:
+              if (!this.conversationId.trim()) { // Did not get it from the header.
+                this.conversationId = activity.conversation?.id ?? ''
+                logger.debug(`Conversation ID: ${this.conversationId}`)
+              }
+              yield activity
+              break
+            default:
+              logger.debug(`Activity type: ${activity.type}`)
+              yield activity
+              break
+          }
+        } catch (error) {
+          logger.error('Failed to parse activity:', error)
+        }
+      } else if (event === 'end') {
+        logger.debug('Stream complete')
+        eventSource.close()
+        break
+      }
+
+      if (eventSource.readyState === 'closed') {
+        logger.debug('Connection closed')
+        eventSource.close()
+        break
+      }
+    }
   }
 
   /**
@@ -146,41 +131,50 @@ export class CopilotStudioClient {
     return userAgent
   }
 
+  private processResponseHeaders (responseHeaders: Headers): void {
+    if (this.settings.useExperimentalEndpoint && !this.settings.directConnectUrl?.trim()) {
+      const islandExperimentalUrl = responseHeaders?.get(CopilotStudioClient.islandExperimentalUrlHeaderKey)
+      if (islandExperimentalUrl) {
+        this.settings.directConnectUrl = islandExperimentalUrl
+        logger.debug(`Island Experimental URL: ${islandExperimentalUrl}`)
+      }
+    }
+
+    this.conversationId = responseHeaders?.get(CopilotStudioClient.conversationIdHeaderKey) ?? ''
+    if (this.conversationId) {
+      logger.debug(`Conversation ID: ${this.conversationId}`)
+    }
+
+    const sanitizedHeaders = new Headers()
+    responseHeaders.forEach((value, key) => {
+      if (key.toLowerCase() !== 'authorization' && key.toLowerCase() !== CopilotStudioClient.conversationIdHeaderKey.toLowerCase()) {
+        sanitizedHeaders.set(key, value)
+      }
+    })
+    logger.debug('Headers received:', sanitizedHeaders)
+  }
+
   /**
    * Starts a new conversation with the Copilot Studio service.
    * @param emitStartConversationEvent Whether to emit a start conversation event. Defaults to true.
-   * @returns A promise that resolves to the initial activity of the conversation.
+   * @returns An async generator yielding the Agent's Activities.
    */
-  public async startConversationAsync (emitStartConversationEvent: boolean = true): Promise<Activity> {
+  public async * startConversationAsync (emitStartConversationEvent: boolean = true): AsyncGenerator<Activity> {
     const uriStart: string = getCopilotStudioConnectionUrl(this.settings)
     const body = { emitStartConversationEvent }
 
-    const config: AxiosRequestConfig = {
-      method: 'post',
-      url: uriStart,
-      headers: {
-        Accept: 'text/event-stream',
-        'Content-Type': 'application/json',
-      },
-      data: body,
-      responseType: 'stream',
-      adapter: 'fetch'
-    }
-
     logger.info('Starting conversation ...')
-    const values = await this.postRequestAsync(config)
-    const act = values[0]
-    logger.info(`Conversation '${act.conversation?.id}' started. Received ${values.length} activities.`, values)
-    return act
+
+    yield * this.postRequestAsync(uriStart, body, 'POST')
   }
 
   /**
    * Sends a question to the Copilot Studio service and retrieves the response activities.
    * @param question The question to ask.
    * @param conversationId The ID of the conversation. Defaults to the current conversation ID.
-   * @returns A promise that resolves to an array of activities containing the responses.
+   * @returns An async generator yielding the Agent's Activities.
    */
-  public async askQuestionAsync (question: string, conversationId: string = this.conversationId) {
+  public async * askQuestionAsync (question: string, conversationId: string = this.conversationId) : AsyncGenerator<Activity> {
     const conversationAccount: ConversationAccount = {
       id: conversationId
     }
@@ -191,34 +185,21 @@ export class CopilotStudioClient {
     }
     const activity = Activity.fromObject(activityObj)
 
-    return this.sendActivity(activity)
+    yield * this.sendActivity(activity)
   }
 
   /**
    * Sends an activity to the Copilot Studio service and retrieves the response activities.
    * @param activity The activity to send.
    * @param conversationId The ID of the conversation. Defaults to the current conversation ID.
-   * @returns A promise that resolves to an array of activities containing the responses.
+   * @returns An async generator yielding the Agent's Activities.
    */
-  public async sendActivity (activity: Activity, conversationId: string = this.conversationId) {
+  public async * sendActivity (activity: Activity, conversationId: string = this.conversationId) : AsyncGenerator<Activity> {
     const localConversationId = activity.conversation?.id ?? conversationId
     const uriExecute = getCopilotStudioConnectionUrl(this.settings, localConversationId)
     const qbody: ExecuteTurnRequest = new ExecuteTurnRequest(activity)
 
-    const config: AxiosRequestConfig = {
-      method: 'post',
-      url: uriExecute,
-      headers: {
-        Accept: 'text/event-stream',
-        'Content-Type': 'application/json',
-      },
-      data: qbody,
-      responseType: 'stream',
-      adapter: 'fetch'
-    }
     logger.info('Sending activity...', activity)
-    const values = await this.postRequestAsync(config)
-    logger.info(`Received ${values.length} activities.`, values)
-    return values
+    yield * this.postRequestAsync(uriExecute, qbody, 'POST')
   }
 }

--- a/packages/agents-copilotstudio-client/src/copilotStudioWebChat.ts
+++ b/packages/agents-copilotstudio-client/src/copilotStudioWebChat.ts
@@ -279,13 +279,14 @@ export class CopilotStudioWebChat {
 
             // Notify WebChat immediately that the message was sent
             subscriber.next(newActivity.id!)
-            subscriber.complete()
 
-            // Now stream the agent's response, but don't block the UI
+            // Stream the agent's response, but don't block the UI
             for await (const responseActivity of client.sendActivity(newActivity)) {
               notifyActivity(responseActivity)
               logger.info('<-- Activity received correctly from Copilot Studio.')
             }
+
+            subscriber.complete()
           } catch (error) {
             logger.error('Error sending Activity to Copilot Studio:', error)
             subscriber.error(error)

--- a/samples/mcs/mcsAgent.ts
+++ b/samples/mcs/mcsAgent.ts
@@ -53,7 +53,7 @@ class McsAgent extends AgentApplication<TurnState> {
     if (cid === undefined || cid === null || cid.length === 0) {
       for await (const newAct of cpsClient.startConversationAsync()) {
         if (newAct.type === ActivityTypes.Message) {
-          await context.sendActivity(newAct.text!)
+          await context.sendActivity(newAct)
           state.setValue('conversation.conversationId', newAct.conversation!.id)
         }
       }

--- a/samples/mcs/mcsAgent.ts
+++ b/samples/mcs/mcsAgent.ts
@@ -51,14 +51,14 @@ class McsAgent extends AgentApplication<TurnState> {
     const cpsClient = this.createClient(oboToken.token!)
 
     if (cid === undefined || cid === null || cid.length === 0) {
-      const newAct = await cpsClient.startConversationAsync()
-      if (newAct.type === ActivityTypes.Message) {
-        await context.sendActivity(newAct.text!)
-        state.setValue('conversation.conversationId', newAct.conversation!.id)
+      for await (const newAct of cpsClient.startConversationAsync()) {
+        if (newAct.type === ActivityTypes.Message) {
+          await context.sendActivity(newAct.text!)
+          state.setValue('conversation.conversationId', newAct.conversation!.id)
+        }
       }
     } else {
-      const resp = await cpsClient!.askQuestionAsync(context.activity.text!, cid)
-      for await (const activity of resp) {
+      for await (const activity of cpsClient!.askQuestionAsync(context.activity.text!, cid)) {
         console.log('Received activity:', activity.type, activity.text)
         if (activity.type === 'message') {
           await context.sendActivity(activity)

--- a/test-agents/copilotstudio-console/src/index.ts
+++ b/test-agents/copilotstudio-console/src/index.ts
@@ -116,6 +116,7 @@ const askQuestion = async (copilotClient: CopilotStudioClient, conversationId: s
         if (replyActivity.type === ActivityTypes.EndOfConversation) {
           console.log(`\n${replyActivity.text}`)
           rl.close()
+          return
         } else {
           printActivity(replyActivity)
         }
@@ -135,7 +136,7 @@ function printActivity (act: Activity): void {
     case ActivityTypes.Message: {
       if (act.textFormat === 'markdown') {
         console.log(`\n${act.text}`)
-        act.suggestedActions?.actions.forEach((action: CardAction) => console.log(`\t${action.value}`))
+        act.suggestedActions?.actions?.forEach((action: CardAction) => console.log(`\t${action.value}`))
       } else {
         console.log(`\n${act.text}`)
       }

--- a/test-agents/copilotstudio-console/src/index.ts
+++ b/test-agents/copilotstudio-console/src/index.ts
@@ -43,7 +43,6 @@ async function acquireS2SToken (baseConfig: msal.Configuration, settings: S2SCon
 async function acquireToken (baseConfig: msal.Configuration, settings: ConnectionSettings): Promise<string> {
   const tokenRequest = {
     scopes: [CopilotStudioClient.scopeFromSettings(settings)],
-    redirectUri: 'http://localhost',
     openBrowser: async (url: string) => {
       await open(url)
     }
@@ -113,26 +112,55 @@ const askQuestion = async (copilotClient: CopilotStudioClient, conversationId: s
       rl.close()
       return
     } else if (answer.length > 0) {
-      const replies = await copilotClient.askQuestionAsync(answer, conversationId)
-      replies.forEach((act: Activity) => {
-        if (act.type === ActivityTypes.Message) {
-          console.log(`\n${act.text}`)
-          act.suggestedActions?.actions.forEach((action: CardAction) => console.log(action.value))
-        } else if (act.type === ActivityTypes.EndOfConversation) {
-          console.log(`\n${act.text}`)
+      for await (const replyActivity of copilotClient.askQuestionAsync(answer, conversationId)) {
+        if (replyActivity.type === ActivityTypes.EndOfConversation) {
+          console.log(`\n${replyActivity.text}`)
           rl.close()
+        } else {
+          printActivity(replyActivity)
         }
-      })
+      }
     }
     await askQuestion(copilotClient, conversationId)
   })
 }
 
+/**
+ * Writes formatted data to the console. This funciton does not handle all of the possible activity types and formats,
+ * it is focused on just a few common types.
+ * @param act The activity to print.
+ */
+function printActivity (act: Activity): void {
+  switch (act.type) {
+    case ActivityTypes.Message: {
+      if (act.textFormat === 'markdown') {
+        console.log(`\n${act.text}`)
+        act.suggestedActions?.actions.forEach((action: CardAction) => console.log(`\t${action.value}`))
+      } else {
+        console.log(`\n${act.text}`)
+      }
+      break
+    }
+    case ActivityTypes.Typing: {
+      console.log('\n...typing...')
+      break
+    }
+    case ActivityTypes.Event: {
+      console.log(`\n(event) ${act.name}`)
+      break
+    }
+    default: console.log(`\n${act.type}`)
+  }
+}
+
 const main = async () => {
   const copilotClient = await createClient()
-  const act: Activity = await copilotClient.startConversationAsync(true)
-  act.suggestedActions?.actions.forEach((action: CardAction) => console.log(action.value))
-  await askQuestion(copilotClient, act.conversation?.id!)
+  let conversationId = ''
+  for await (const act of copilotClient.startConversationAsync(true)) {
+    printActivity(act)
+    conversationId = act.conversation?.id ?? ''
+  }
+  await askQuestion(copilotClient, conversationId!)
 }
 
 main().catch(e => console.log(e))


### PR DESCRIPTION
Fixes #595
Fixes #598

## Description
This PR updates the Copilot Studio Client package to use an EventSource client and return the Agent's messages as they arrive rather than waiting for the entire response.
It also fixes a bug in copilotStudioWebChat to notify WebChat immediately that the message was sent and then process the agent's response without blocking the UI.

>**NOTE:**
These changes **break compatibility** for customers using the _startConversationAsync_, _askQuestionAsync_, and _sendActivity_ methods directly, not for those using the _copilotStudioWebChat_ _createConnection_ method.

### Detailed Changes
- In **_copilotStudioClient_**:
   - Replaced _axios_ with _EventSourceClient_ to handle streaming responses asynchronously. 
   - Updated the _postRequestAsync_ method to yield each Agent's response until the connection is closed. 
   - Updated the _startConversationAsync_, _askQuestionAsync_, and _sendActivity_ methods to handle the _AsyncIterator_ containing the agent's responses.
- In **_copilotStudioWebChat_**:
   - Updated the _createConnection_ method to handle the agent's async responses with `for await`.
   - Moved the `subscriber.next` call to notify WebChat immediately that the message was sent and then process the agent's response without blocking the UI.
- Updated **_copilotstudio-console_** test-agent and **_mcsAgent_** sample to handle the agent's async responses with `for await`.
- Added the _printActivity_ function in  **_copilotstudio-console_** to format the activities depending on their type.
- Replaced _axios_ dependency with _eventsource-client_ in _agents-copilotstudioclient_.
- Updated method signatures in _**agents-copilotstudio-client.api.md**_

## Testing
These images show the samples processing multiple activities in one turn.
<img width="1955" height="1015" alt="image" src="https://github.com/user-attachments/assets/a5f15b20-dd52-4cbe-866d-7d6183f5bb63" />

Here we can see the User message marked as sent while the agent's response is being processed.
<img width="1607" height="886" alt="image" src="https://github.com/user-attachments/assets/93d7920c-a021-401d-921d-8f88e26d704a" />