### PR TITLE
Fix proactive sample

### DIFF
--- a/samples/basic/proactive.ts
+++ b/samples/basic/proactive.ts
@@ -61,7 +61,7 @@ const startServer = (agent: AgentApplication<TurnState<any, any>>, authConfigura
     },
     async (context) => {
       const conversationReference = context.activity.getConversationReference()
-      await adapter.continueConversation(conversationReference, async (context) => {
+      await adapter.continueConversation(authConfig.clientId!, conversationReference, async (context) => {
         await context.sendActivity(activity)
       })
     })
@@ -84,7 +84,7 @@ const startServer = (agent: AgentApplication<TurnState<any, any>>, authConfigura
       serviceUrl: 'https://webchat.botframework.com/'
     }
     const msg = 'This is a proactive message sent from the server. timestamp ' + Date.now()
-    await adapter.continueConversation(conversationReference, async (context) => {
+    await adapter.continueConversation(authConfig.clientId!, conversationReference, async (context) => {
       await context.sendActivity(msg)
     })
     res.status(200).send(msg)


### PR DESCRIPTION
## Description 

This PR adds the missing parameters in the calls the proactive sample makes to the ContinueConversation method.

>NOTE:
The sample works on WebChat but not on MSTeams. This issue will be address separatelly.

## Testing

This image shows the sample working on WebChat.
<img width="901" height="903" alt="image" src="https://github.com/user-attachments/assets/3b648c45-0705-4478-a241-f82f740fca29" />
