### PR TITLE
Fix AgentApplication unit tests

### DIFF
--- a/packages/agents-hosting/test/hosting/app/authorization.test.ts
+++ b/packages/agents-hosting/test/hosting/app/authorization.test.ts
@@ -67,8 +67,8 @@ describe('AgentApplication', () => {
 
     const authHandlers = (app.authorization as any).manager._handlers
     assert.equal(Object.keys(authHandlers).length, 2)
-    const one = authHandlers['authOne']._settings
-    const two = authHandlers['authTwo']._settings
+    const one = authHandlers['authOne']._options
+    const two = authHandlers['authTwo']._options
     assert.equal(one.name, 'FirstConnection')
     assert.equal(two.name, 'SecondConnection')
   })
@@ -94,7 +94,7 @@ describe('AgentApplication', () => {
         }
       })
 
-      const authHandler: AzureBotAuthorizationOptions = (app.authorization as any).manager._handlers['testAuth']._settings
+      const authHandler: AzureBotAuthorizationOptions = (app.authorization as any).manager._handlers['testAuth']._options
       assert.equal(authHandler.name, 'EnvConnection')
       assert.equal(authHandler.title, 'Env Title')
       assert.equal(authHandler.text, 'Env Text')


### PR DESCRIPTION
## Description

This PR fixes two unit tests that failed after merging the new Auth changes. The _settings_ property is now called _options_ in new Authentication.

## Testing
The tests failing before and passing after the changes.
<img width="800" height="317" alt="image" src="https://github.com/user-attachments/assets/13dadb4d-afdd-4ceb-b4c1-7c9e53ccd16a" />

<img width="950" height="367" alt="image" src="https://github.com/user-attachments/assets/d85d7c2a-289a-400c-97b4-105415cc149c" />
