### PR TITLE
Refactor createConversation to use normalized activity parameters

### DIFF
--- a/packages/agents-hosting/src/connector-client/connectorClient.ts
+++ b/packages/agents-hosting/src/connector-client/connectorClient.ts
@@ -166,14 +166,14 @@ export class ConnectorClient {
    * @returns The conversation resource response.
    */
   public async createConversation (body: ConversationParameters): Promise<ConversationResourceResponse> {
-    // const payload = normalizeOutgoingConvoParams(body)
+    const payload = normalizeOutgoingActivity(body)
     const config: AxiosRequestConfig = {
       method: 'post',
       url: '/v3/conversations',
       headers: {
         'Content-Type': 'application/json'
       },
-      data: body
+      data: payload
     }
     const response: AxiosResponse = await this._axiosInstance(config)
     return response.data


### PR DESCRIPTION
Replaces Steven's PR #703 

## Description
Implements the `normalizeOutgoingActivity()` function within the 'createConversation'. When rules apply, this transforms the payload into a format accepted by the connector service by capturing the `agent` property value, removing that property, creating the `bot` property and applying the stored value to it. It is used in request transforms and when creating conversations to ensure consistent, backward‑compatible payloads.

