### PR TITLE
Fix: Do not stringify the json before sending it to the webserver.

### DIFF
--- a/packages/agents-hosting/src/cloudAdapter.ts
+++ b/packages/agents-hosting/src/cloudAdapter.ts
@@ -351,7 +351,7 @@ export class CloudAdapter extends BaseAdapter {
       await this.runMiddleware(context, logic)
       const invokeResponse = this.processTurnResults(context)
       logger.debug('Activity Response (invoke/expect replies): ', invokeResponse)
-      return end(invokeResponse?.status ?? StatusCodes.OK, JSON.stringify(invokeResponse?.body), true)
+      return end(invokeResponse?.status ?? StatusCodes.OK, invokeResponse?.body, true)
     }
 
     await this.runMiddleware(context, logic)

--- a/packages/agents-hosting/test/hosting/adapter/cloudAdapter.test.ts
+++ b/packages/agents-hosting/test/hosting/adapter/cloudAdapter.test.ts
@@ -141,7 +141,7 @@ describe('CloudAdapter', function () {
 
       sinon.assert.calledOnceWithExactly((res as any).status, 200)
       sinon.assert.calledOnceWithExactly((res as any).setHeader, 'content-type', 'application/json')
-      sinon.assert.calledOnceWithExactly((res as any).send, JSON.stringify({ activities: [activity] }))
+      sinon.assert.calledOnceWithExactly((res as any).send, { activities: [activity] })
       sinon.assert.notCalled(createConnectorClientWithIdentitySpy) // No connector client created for ExpectReplies without serviceUrl
 
       stubfromObject.restore()


### PR DESCRIPTION
Fixes #762 - This change removes a call to JSON.stringify when responding to invokes. The underying webserver can handle the serialization of the data properly, especially when the content type header is set. 

With the stringify in place, when using Restify, the server treats the json string as a string, resulting in what _looks like_ a valid response but is treated by Teams as bad json.