### PR TITLE
Fix: Update token acquisition logic for agentic scenarios

### DIFF
--- a/packages/agents-hosting/src/auth/msalTokenProvider.ts
+++ b/packages/agents-hosting/src/auth/msalTokenProvider.ts
@@ -211,8 +211,8 @@ export class MsalTokenProvider implements AuthProvider {
       data.client_secret = this.connectionSettings.clientSecret
     }
 
-    if(data.grant_type !== 'user_fic') {
-      data.client_info = '2'; 
+    if (data.grant_type !== 'user_fic') {
+      data.client_info = '2'
     }
 
     const token = await axios.post(


### PR DESCRIPTION
Added client_info = 2 for Non User auth scenarios ( entra seems to want this now )

Updated user level acquireTokenByForAgenticScenarios to pass agentAppInstanceID and AgentToken for FIC exchange.

This pull request updates the `MsalTokenProvider` class to improve how authentication tokens are acquired, particularly for agentic scenarios. The main changes focus on adjusting token request parameters and method signatures to ensure correct handling of authentication flows.

**Authentication flow improvements:**

* Added a conditional to include `client_info = '2'` in the token request payload for all grant types except `'user_fic'`, ensuring proper client information is provided for most authentication scenarios.

* Updated the call to `acquireTokenByForAgenticScenarios` to pass `agentAppInstanceId` as a parameter instead of `instanceToken`, aligning the method signature and invocation with agentic authentication requirements.
