### PR TITLE
Bump qs version to 6.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2573,7 +2573,7 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -2582,7 +2582,7 @@
         "http-errors": "^2.0.0",
         "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
+        "qs": "^6.14.1",
         "raw-body": "^3.0.1",
         "type-is": "^2.0.1"
       },
@@ -5955,7 +5955,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
## Description

This PR updates `body-parser` version to ultimatelly update `qs` dependency to a safe version (6.14.1).

## Testing
The image displays the audit command indicating that there are no vulnerabilities detected.
<img width="651" height="68" alt="image" src="https://github.com/user-attachments/assets/7fc94a75-093d-4b82-b4c7-90b3da616101" />
