### PR TITLE
Implement auto signin handler

### DIFF
--- a/packages/agents-hosting/src/app/agentApplication.ts
+++ b/packages/agents-hosting/src/app/agentApplication.ts
@@ -125,7 +125,7 @@ export class AgentApplication<TState extends TurnState> {
       this._adapter = new CloudAdapter()
     }
 
-    if (this._options.authorization) {
+    if (this._options.userAuthorization || this._options.authorization) {
       this._authorizationManager = new AuthorizationManager(this, this._adapter.connectionManager)
       this._authorization = new UserAuthorization(this._authorizationManager)
     }
@@ -433,7 +433,7 @@ export class AgentApplication<TState extends TurnState> {
    *
    */
   public onSignInSuccess (handler: (context: TurnContext, state: TurnState, id?: string) => Promise<void>): this {
-    if (this.options.authorization) {
+    if (this.options.userAuthorization || this.options.authorization) {
       this.authorization.onSignInSuccess(handler)
     } else {
       throw new Error(
@@ -463,7 +463,7 @@ export class AgentApplication<TState extends TurnState> {
    *
    */
   public onSignInFailure (handler: (context: TurnContext, state: TurnState, id?: string) => Promise<void>): this {
-    if (this.options.authorization) {
+    if (this.options.userAuthorization || this.options.authorization) {
       this.authorization.onSignInFailure(handler)
     } else {
       throw new Error(

--- a/packages/agents-hosting/src/app/agentApplicationBuilder.ts
+++ b/packages/agents-hosting/src/app/agentApplicationBuilder.ts
@@ -69,10 +69,14 @@ export class AgentApplicationBuilder<TState extends TurnState = TurnState> {
    */
   public withAuthorization (authHandlers: AuthorizationOptions): this
   public withAuthorization (options: UserAuthorizationOptions | AuthorizationOptions): this {
-    if ('handlers' in options) {
+    if (
+      'handlers' in options &&
+      typeof options.handlers === 'object' &&
+      Object.values(options.handlers).some(handler => typeof handler === 'object' && 'settings' in handler)
+    ) {
       this._options.userAuthorization = options as UserAuthorizationOptions
     } else {
-      this._options.authorization = options
+      this._options.authorization = options as AuthorizationOptions
     }
     return this
   }

--- a/packages/agents-hosting/src/app/agentApplicationBuilder.ts
+++ b/packages/agents-hosting/src/app/agentApplicationBuilder.ts
@@ -6,7 +6,7 @@
 import { Storage } from '../storage'
 import { AgentApplication } from './agentApplication'
 import { AgentApplicationOptions } from './agentApplicationOptions'
-import { AuthorizationOptions } from './auth/types'
+import { AuthorizationOptions, UserAuthorizationOptions } from './auth/types'
 import { TurnState } from './turnState'
 
 /**
@@ -55,12 +55,25 @@ export class AgentApplicationBuilder<TState extends TurnState = TurnState> {
   // }
 
   /**
+   * Sets user authorization options for the AgentApplication.
+   * @param options The user authorization configuration
+   * @returns This builder instance for chaining
+   */
+  public withAuthorization (options: UserAuthorizationOptions): this
+  /**
+   * @deprecated Use `withAuthorization(UserAuthorizationOptions)` instead.
+   *
    * Sets authentication options for the AgentApplication.
    * @param authHandlers The user identity authentication options
    * @returns This builder instance for chaining
    */
-  public withAuthorization (authHandlers: AuthorizationOptions): this {
-    this._options.authorization = authHandlers
+  public withAuthorization (authHandlers: AuthorizationOptions): this
+  public withAuthorization (options: UserAuthorizationOptions | AuthorizationOptions): this {
+    if ('handlers' in options) {
+      this._options.userAuthorization = options as UserAuthorizationOptions
+    } else {
+      this._options.authorization = options
+    }
     return this
   }
 

--- a/packages/agents-hosting/src/app/agentApplicationOptions.ts
+++ b/packages/agents-hosting/src/app/agentApplicationOptions.ts
@@ -10,7 +10,7 @@ import { AdaptiveCardsOptions } from './adaptiveCards'
 import { InputFileDownloader } from './inputFileDownloader'
 import { TurnState } from './turnState'
 import { HeaderPropagationDefinition } from '../headerPropagation'
-import { AuthorizationOptions } from './auth/types'
+import { AuthorizationOptions, UserAuthorizationOptions } from './auth/types'
 import { Connections } from '../auth/connections'
 
 /**
@@ -90,6 +90,8 @@ export interface AgentApplicationOptions<TState extends TurnState> {
   fileDownloaders?: InputFileDownloader<TState>[];
 
   /**
+   * @deprecated Use `userAuthorization` instead.
+   *
    * Handlers for managing user authentication and authorization within the agent.
    * This includes OAuth flows, token management, and permission validation.
    * Use this to implement secure access to protected resources or user-specific data.
@@ -97,6 +99,28 @@ export interface AgentApplicationOptions<TState extends TurnState> {
    * @default undefined (no authorization required)
    */
   authorization?: AuthorizationOptions;
+
+  /**
+   * Configuration for user authentication and authorization within the agent.
+   * This includes OAuth flows, token management, and permission validation.
+   * Use this to implement secure access to protected resources or user-specific data.
+   *
+   * @example
+   * ```typescript
+   * userAuthorization: {
+   *   defaultHandlerName: 'graph',
+   *   autoSignIn: true,
+   *   handlers: {
+   *     graph: {
+   *       settings: { text: 'Sign in', title: 'Graph Sign In' }
+   *     },
+   *   }
+   * }
+   * ```
+   *
+   * @default undefined (no authorization required)
+   */
+  userAuthorization?: UserAuthorizationOptions;
 
   /**
    * Configuration options for handling Adaptive Card actions and interactions.

--- a/packages/agents-hosting/src/app/agentApplicationOptions.ts
+++ b/packages/agents-hosting/src/app/agentApplicationOptions.ts
@@ -109,7 +109,7 @@ export interface AgentApplicationOptions<TState extends TurnState> {
    * ```typescript
    * userAuthorization: {
    *   defaultHandlerName: 'graph',
-   *   autoSignIn: true,
+   *   autoSignIn: () => true,
    *   handlers: {
    *     graph: {
    *       settings: { text: 'Sign in', title: 'Graph Sign In' }

--- a/packages/agents-hosting/src/app/auth/authorizationManager.ts
+++ b/packages/agents-hosting/src/app/auth/authorizationManager.ts
@@ -118,7 +118,7 @@ export class AuthorizationManager {
 
     // Validate supported types: agentic, and default (Azure Bot - undefined)
     const supportedTypes = ['agentic', undefined]
-    if (result.type && !supportedTypes.includes(result.type.toLowerCase())) {
+    if (result.type && !supportedTypes.includes(result.type)) {
       throw new Error(`Unsupported authorization handler type: '${result.type}' for auth handler: '${id}'. Supported types are: '${supportedTypes.filter(Boolean).join('\', \'')}'.`)
     }
 
@@ -147,7 +147,8 @@ export class AuthorizationManager {
     const handlers = active?.handlers ?? this.mapHandlers(await getHandlerIds(context.activity) ?? []) ?? []
 
     // AutoSignIn feature: performs automatic sign-in using the provided default or first available handler.
-    if (this._userAuthorizationOptions.autoSignIn?.(context) && handlers.length === 0) {
+    const shouldAutoSignIn = await this._userAuthorizationOptions.autoSignIn?.(context)
+    if (shouldAutoSignIn && handlers.length === 0) {
       const firstHandler = Object.values(this._handlers)[0]
       const defaultHandler = this._handlers[this._userAuthorizationOptions.defaultHandlerName ?? '']
       if (!defaultHandler && this._userAuthorizationOptions.defaultHandlerName) {

--- a/packages/agents-hosting/src/app/auth/types.ts
+++ b/packages/agents-hosting/src/app/auth/types.ts
@@ -75,7 +75,7 @@ export interface UserAuthorizationOptions {
   defaultHandlerName?: string
   /**
    * Indicates whether to automatically sign in users when they interact with the application.
-   * @remarks Enabled by default if not specified.
+   * @remarks Auto sign-in is enabled by default and remains enabled unless explicitly disabled (for example, by setting the corresponding configuration or environment variable to 'false').
    */
   autoSignIn?: AutoSignInSelector
   /**

--- a/packages/agents-hosting/src/app/auth/types.ts
+++ b/packages/agents-hosting/src/app/auth/types.ts
@@ -37,8 +37,19 @@ export type AutoSignInSelector = (context: TurnContext) => Promise<boolean> | bo
 
 /**
  * User authorization configuration options.
+ *
  * @remarks
- * Use this interface to configure authorization handlers with explicit settings.
+ * Properties can be configured via environment variables.
+ * Use the format:
+ * `AgentApplication__UserAuthorization__{propertyName}`
+ *
+ * @example
+ * ```env
+ * # For all handlers
+ *
+ * AGENTAPPLICATION__USERAUTHORIZATION__DEFAULTHANDLERNAME=graph
+ * AGENTAPPLICATION__USERAUTHORIZATION__AUTOSIGNIN=true
+ * ```
  *
  * @example
  * ```typescript

--- a/packages/agents-hosting/src/app/auth/types.ts
+++ b/packages/agents-hosting/src/app/auth/types.ts
@@ -11,9 +11,95 @@ import { TokenResponse } from '../../oauth'
 import { Connections } from '../../auth/connections'
 
 /**
- * Authorization configuration options.
+ * Handler options type for authorization handlers.
  */
-export type AuthorizationOptions = Record<string, AzureBotAuthorizationOptions | AgenticAuthorizationOptions>
+export type AuthorizationHandlerOptions = AzureBotAuthorizationOptions | AgenticAuthorizationOptions
+
+/**
+ * Configuration for an individual authorization handler.
+ */
+export interface AuthorizationHandlerConfig {
+  /**
+   * The settings for the authorization handler.
+   */
+  settings: AuthorizationHandlerOptions
+}
+
+/**
+ * A record of authorization handler configurations keyed by their unique identifiers.
+ */
+export type AuthorizationHandlers = Record<string, AuthorizationHandlerConfig>
+
+/**
+ * Function type for selecting whether to auto sign-in.
+ */
+export type AutoSignInSelector = (context: TurnContext) => Promise<boolean> | boolean
+
+/**
+ * User authorization configuration options.
+ * @remarks
+ * Use this interface to configure authorization handlers with explicit settings.
+ *
+ * @example
+ * ```typescript
+ * userAuthorization: {
+ *   defaultHandlerName: 'graph',
+ *   autoSignIn: () => true,
+ *   handlers: {
+ *     graph: {
+ *       settings: { text: 'Sign in with Microsoft Graph', title: 'Graph Sign In' }
+ *     },
+ *     github: {
+ *       settings: { text: 'Sign in with GitHub', title: 'GitHub Sign In' }
+ *     },
+ *   }
+ * }
+ * ```
+ */
+export interface UserAuthorizationOptions {
+  /**
+   * The name of the default authorization handler to use when no specific handler is specified.
+   * @remarks If not provided, the first handler in the list will be used as the default.
+   */
+  defaultHandlerName?: string
+  /**
+   * Indicates whether to automatically sign in users when they interact with the application.
+   * @remarks Enabled by default if not specified.
+   */
+  autoSignIn?: AutoSignInSelector
+  /**
+   * A record of authorization handlers keyed by their unique identifiers.
+   */
+  handlers: AuthorizationHandlers
+}
+
+/**
+ * Authorization configuration options.
+ * @deprecated Use {@link UserAuthorizationOptions} with the `userAuthorization` property instead.
+ * This flat structure will be removed in a future version.
+ *
+ * @example
+ * ```typescript
+ * // Deprecated:
+ * authorization: {
+ *   graph: { text: '...', title: '...' },
+ *   github: { text: '...', title: '...' },
+ * }
+ *
+ * // Use instead:
+ * userAuthorization: {
+ *   handlers: {
+ *     graph: {
+ *       settings: { text: '...', title: '...' }
+ *     },
+ *     github: {
+ *       settings: { text: '...', title: '...' }
+ *     },
+ *   }
+ * }
+ * ```
+ */
+export type AuthorizationOptions = Record<string, AuthorizationHandlerOptions>
 
 /**
  * Represents the status of a handler registration attempt.

--- a/packages/agents-hosting/test/hosting/app/authorization.test.ts
+++ b/packages/agents-hosting/test/hosting/app/authorization.test.ts
@@ -27,7 +27,7 @@ describe('AgentApplication', () => {
         authorization: {}
       })
       assert.equal(app.options.authorization, undefined)
-    }, { message: 'The AgentApplication.authorization does not have any auth handlers' })
+    }, { message: 'No authorization handlers configured. Provide handlers via \'AgentApplication.userAuthorization.handlers\' property.' })
   })
 
   it('should initialize successfully with valid auth configuration', () => {


### PR DESCRIPTION
Fixes #857

> [!IMPORTANT]
> This PR will most likely conflict with PR #872

## Description
This PR adds automatic sign-in capability to the `UserAuthorization` flow, allowing users to be automatically authenticated when first interacting with the application.
Additionally, the authorization configuration changed to include this feature and stays close to .NET settings.

**New `userAuthorization` configuration options:**
- `autoSignIn` - A selector function to enable/disable automatic sign-in per context
- `defaultHandlerName` - Specifies which handler to use for auto sign-in
- `handlers` - New structured format for configuring authorization handlers

**Environment variables support:**
- `AGENTAPPLICATION__USERAUTHORIZATION__DEFAULTHANDLERNAME`
- `AGENTAPPLICATION__USERAUTHORIZATION__AUTOSIGNIN`

**Example usage:**
```typescript
userAuthorization: {
  defaultHandlerName: 'graph',
  autoSignIn: () => true, // Enabled for all contexts
  handlers: {
    graph: {
      settings: { text: 'Sign in with Microsoft Graph', title: 'Graph Sign In' }
    },
    github: {
      settings: { text: 'Sign in with GitHub', title: 'GitHub Sign In' }
    }
  }
}
```

#### ⚠️ Deprecations

| Deprecated | Replacement |
|------------|-------------|
| `AgentApplicationOptions.authorization` | `AgentApplicationOptions.userAuthorization` |
| `AgentApplicationBuilder.withAuthorization(AuthorizationOptions)` | `AgentApplicationBuilder.withAuthorization(UserAuthorizationOptions)` |
| `AuthorizationOptions` type (flat structure) | `UserAuthorizationOptions` with nested `handlers` config |

**Migration example:**

```typescript
// ❌ Deprecated
authorization: {
  graph: { text: '...', title: '...' },
  github: { text: '...', title: '...' },
}

// ✅ New format
userAuthorization: {
  defaultHandlerName: 'graph',
  autoSignIn: () => true,
  handlers: {
    graph: {
      settings: { text: '...', title: '...' }
    },
    github: {
      settings: { text: '...', title: '...' }
    },
  }
}
```

## Testing
The following image shows the feature working.
<img width="1512" height="775" alt="imagen" src="https://github.com/user-attachments/assets/675d2d25-bae4-41a5-b346-8c6a2075c03c" />
