### PR TITLE
Fix Consent error for MS Teams + Copilot

### DIFF
--- a/packages/agents-hosting/src/app/auth/handlers/azureBotAuthorization.ts
+++ b/packages/agents-hosting/src/app/auth/handlers/azureBotAuthorization.ts
@@ -547,10 +547,11 @@ export class AzureBotAuthorization implements AuthorizationHandler {
   }
 
   /**
-   * Sends an InvokeResponse activity if the channel is Microsoft Teams.
+   * Sends an InvokeResponse activity if the channel is Microsoft Teams, including Copilot within MS Teams.
    */
   private sendInvokeResponse <T>(context: TurnContext, response: InvokeResponse<T>) {
-    if (context.activity.channelId !== Channels.Msteams) {
+    const [parentChannel] = Activity.parseChannelId(context.activity.channelId!)
+    if (parentChannel !== Channels.Msteams) {
       return Promise.resolve()
     }
 


### PR DESCRIPTION
Fixes #829

## Description
This PR fixes an issue where using an Agent through Copilot chat with SSO, when requiring consent flow, it wouldn't let the user sign-in properly. This issue was due to a condition only applied to MS Teams channel specifically, not sending the HTTP 412 status to the channel, so it can retry the consent flow.

## Testing
The following image shows the consent card being shown.
<img width="1533" height="1448" alt="imagen" src="https://github.com/user-attachments/assets/9469f40b-bfec-4a27-a0c2-eb4839ace1ed" />
