### PR TITLE
Add Zod as agents-hosting dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7331,7 +7331,8 @@
         "axios": "^1.13.2",
         "jsonwebtoken": "^9.0.3",
         "jwks-rsa": "^3.2.2",
-        "object-path": "^0.11.8"
+        "object-path": "^0.11.8",
+        "zod": "3.25.75"
       },
       "devDependencies": {
         "@types/object-path": "^0.11.4"

--- a/packages/agents-hosting/package.json
+++ b/packages/agents-hosting/package.json
@@ -25,7 +25,8 @@
     "axios": "^1.13.2",
     "jsonwebtoken": "^9.0.3",
     "jwks-rsa": "^3.2.2",
-    "object-path": "^0.11.8"
+    "object-path": "^0.11.8",
+    "zod": "3.25.75"
   },
   "license": "MIT",
   "files": [


### PR DESCRIPTION
Fixes #889

## Description
This PR adds the Zod library to agents-hosting as a direct dependency so it doesn't rely on agents-activity dependencies.

## Testing
Does not require testing, as install and build passes.