### PR TITLE
Update CODEOWNERS to include new owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,7 @@
 # CODEOWNERS for Microsoft 365 Agents SDK for JS
 
 # Global ownership - fallback for any files not covered by more specific rules
-* @microsoft/agents-sdk
+* @microsoft/agents-admin
+* @benbrown
 #   Team is found here:
 #   https://github.com/orgs/microsoft/teams/agents-sdk

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,6 @@
 # CODEOWNERS for Microsoft 365 Agents SDK for JS
 
 # Global ownership - fallback for any files not covered by more specific rules
-* @microsoft/agents-sdk
-* @benbrown
+* @microsoft/agents-sdk @benbrown
 #   Team is found here:
 #   https://github.com/orgs/microsoft/teams/agents-sdk

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,7 @@
 # CODEOWNERS for Microsoft 365 Agents SDK for JS
 
 # Global ownership - fallback for any files not covered by more specific rules
-* @microsoft/agents-sdk @benbrown
+* @microsoft/agents-admin
+* @benbrown
 #   Team is found here:
-#   https://github.com/orgs/microsoft/teams/agents-sdk
+#   https://github.com/orgs/microsoft/teams/agents-admin

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,5 @@
 
 # Global ownership - fallback for any files not covered by more specific rules
 * @microsoft/agents-admin
-* @benbrown
 #   Team is found here:
 #   https://github.com/orgs/microsoft/teams/agents-admin

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS for Microsoft 365 Agents SDK for JS
 
 # Global ownership - fallback for any files not covered by more specific rules
-* @microsoft/agents-admin
+* @microsoft/agents-sdk
 * @benbrown
 #   Team is found here:
 #   https://github.com/orgs/microsoft/teams/agents-sdk


### PR DESCRIPTION
This pull request makes a minor update to the `CODEOWNERS` file, changing the default code ownership to the `@microsoft/agents-admin` team and adding `@benbrown` as an owner.Fix code owners to add correct groups