### PR TITLE
[#923] Add OTel to agents-hosting-dialogs

### DIFF
--- a/packages/agents-hosting-dialogs/src/dialogContext.ts
+++ b/packages/agents-hosting-dialogs/src/dialogContext.ts
@@ -532,7 +532,6 @@ export class DialogContext {
         activity: this.context.activity,
         dialogId: this.activeDialog?.id,
         name: activeDialogDefinition?.constructor.name,
-        reason: DialogReason.endCalled,
       })
 
       // End the active dialog

--- a/packages/agents-hosting-dialogs/src/dialogContext.ts
+++ b/packages/agents-hosting-dialogs/src/dialogContext.ts
@@ -19,6 +19,7 @@ import { DialogTurnResult } from './dialogTurnResult'
 import { DialogTurnStatus } from './dialogTurnStatus'
 import { Choice } from './choices'
 import { Activity } from '@microsoft/agents-activity'
+import { DialogsTraceDefinitions, trace } from './observability'
 
 /**
  * Wraps a promise in a try-catch that automatically enriches errors with extra dialog context.
@@ -248,24 +249,36 @@ export class DialogContext {
      *
      */
   async beginDialog (dialogId: string, options?: object): Promise<DialogTurnResult> {
-    // Lookup dialog
-    const dialog: Dialog<{}> = this.findDialog(dialogId)
-    if (!dialog) {
-      throw new DialogContextError(
-                `DialogContext.beginDialog(): A dialog with an id of '${dialogId}' wasn't found.`,
-                this
-      )
-    }
+    return trace(DialogsTraceDefinitions.contextBegin, async ({ record }) => {
+      record({
+        dialogId,
+        parentId: this.activeDialog?.id,
+        activity: this.context.activity,
+      })
 
-    // Push new instance onto stack.
-    const instance: DialogInstance<any> = {
-      id: dialogId,
-      state: {},
-    }
-    this.stack.push(instance)
+      // Lookup dialog
+      const dialog: Dialog<{}> = this.findDialog(dialogId)
+      if (!dialog) {
+        throw new DialogContextError(
+                    `DialogContext.beginDialog(): A dialog with an id of '${dialogId}' wasn't found.`,
+                    this
+        )
+      }
 
-    // Call dialogs begin() method.
-    return wrapErrors(this, dialog.beginDialog(this, options))
+      record({ name: dialog.constructor.name })
+
+      // Push new instance onto stack.
+      const instance: DialogInstance<any> = {
+        id: dialogId,
+        state: {},
+      }
+      this.stack.push(instance)
+
+      // Call dialogs begin() method.
+      const result = await wrapErrors(this, dialog.beginDialog(this, options))
+      record({ status: result?.status })
+      return result
+    })
   }
 
   /**
@@ -286,36 +299,52 @@ export class DialogContext {
      *
      */
   async cancelAllDialogs (cancelParents = false, eventName?: string, eventValue?: any): Promise<DialogTurnResult> {
-    eventName = eventName || DialogEvents.cancelDialog
-    if (this.stack.length > 0 || this.parent !== undefined) {
-      // Cancel all local and parent dialogs while checking for interception
-      let notify = false
+    return trace(DialogsTraceDefinitions.contextCancelAll, async ({ record }) => {
+      eventName = eventName || DialogEvents.cancelDialog
+      const activeDialogDefinition = this.activeDialog ? this.findDialog(this.activeDialog.id) : undefined
 
-      let dialogContext: DialogContext = this
-      while (dialogContext !== undefined) {
-        if (dialogContext.stack.length > 0) {
-          // Check to see if the dialog wants to handle the event
-          // - We skip notifying the first dialog which actually called cancelAllDialogs()
-          if (notify) {
-            const handled = await dialogContext.emitEvent(eventName, eventValue, false, false)
-            if (handled) {
-              break
+      record({
+        activity: this.context.activity,
+        cancelParents,
+        dialogId: this.activeDialog?.id,
+        eventName,
+        name: activeDialogDefinition?.constructor.name,
+      })
+
+      let result: DialogTurnResult
+      if (this.stack.length > 0 || this.parent !== undefined) {
+        // Cancel all local and parent dialogs while checking for interception
+        let notify = false
+
+        let dialogContext: DialogContext = this
+        while (dialogContext !== undefined) {
+          if (dialogContext.stack.length > 0) {
+            // Check to see if the dialog wants to handle the event
+            // - We skip notifying the first dialog which actually called cancelAllDialogs()
+            if (notify) {
+              const handled = await dialogContext.emitEvent(eventName, eventValue, false, false)
+              if (handled) {
+                break
+              }
             }
+
+            // End the active dialog
+            await dialogContext.endActiveDialog(DialogReason.cancelCalled)
+          } else {
+            dialogContext = cancelParents ? dialogContext.parent : undefined
           }
 
-          // End the active dialog
-          await dialogContext.endActiveDialog(DialogReason.cancelCalled)
-        } else {
-          dialogContext = cancelParents ? dialogContext.parent : undefined
+          notify = true
         }
 
-        notify = true
+        result = { status: DialogTurnStatus.cancelled }
+      } else {
+        result = { status: DialogTurnStatus.empty }
       }
 
-      return { status: DialogTurnStatus.cancelled }
-    } else {
-      return { status: DialogTurnStatus.empty }
-    }
+      record({ status: result.status })
+      return result
+    })
   }
 
   /**
@@ -430,33 +459,46 @@ export class DialogContext {
      *
      */
   async continueDialog (): Promise<DialogTurnResult> {
-    // if we are continuing and haven't emitted the activityReceived event, emit it
-    // NOTE: This is backward compatible way for activity received to be fired even if you have legacy dialog loop
-    if (!this.context.turnState.has(ACTIVITY_RECEIVED_EMITTED)) {
-      this.context.turnState.set(ACTIVITY_RECEIVED_EMITTED, true)
+    return trace(DialogsTraceDefinitions.contextContinue, async ({ record }) => {
+      record({
+        dialogId: this.activeDialog?.id,
+        activity: this.context.activity,
+      })
 
-      // Dispatch "activityReceived" event
-      // - This fired from teh leaf and will queue up any interruptions.
-      await this.emitEvent(DialogEvents.activityReceived, this.context.activity, true, true)
-    }
+      // if we are continuing and haven't emitted the activityReceived event, emit it
+      // NOTE: This is backward compatible way for activity received to be fired even if you have legacy dialog loop
+      if (!this.context.turnState.has(ACTIVITY_RECEIVED_EMITTED)) {
+        this.context.turnState.set(ACTIVITY_RECEIVED_EMITTED, true)
 
-    // Check for a dialog on the stack
-    const instance: DialogInstance<any> = this.activeDialog
-    if (instance) {
-      // Lookup dialog
-      const dialog: Dialog<{}> = this.findDialog(instance.id)
-      if (!dialog) {
-        throw new DialogContextError(
-                    `DialogContext.continueDialog(): Can't continue dialog. A dialog with an id of '${instance.id}' wasn't found.`,
-                    this
-        )
+        // Dispatch "activityReceived" event
+        // - This fired from teh leaf and will queue up any interruptions.
+        await this.emitEvent(DialogEvents.activityReceived, this.context.activity, true, true)
       }
 
-      // Continue execution of dialog
-      return wrapErrors(this, dialog.continueDialog(this))
-    } else {
-      return { status: DialogTurnStatus.empty }
-    }
+      // Check for a dialog on the stack
+      const instance: DialogInstance<any> = this.activeDialog
+      let result: DialogTurnResult
+      if (instance) {
+        // Lookup dialog
+        const dialog: Dialog<{}> = this.findDialog(instance.id)
+        if (!dialog) {
+          throw new DialogContextError(
+                        `DialogContext.continueDialog(): Can't continue dialog. A dialog with an id of '${instance.id}' wasn't found.`,
+                        this
+          )
+        }
+
+        record({ name: dialog.constructor.name })
+
+        // Continue execution of dialog
+        result = await wrapErrors(this, dialog.continueDialog(this))
+      } else {
+        result = { status: DialogTurnStatus.empty }
+      }
+
+      record({ status: result.status })
+      return result
+    })
   }
 
   /**
@@ -483,27 +525,42 @@ export class DialogContext {
      *
      */
   async endDialog (result?: any): Promise<DialogTurnResult> {
-    // End the active dialog
-    await this.endActiveDialog(DialogReason.endCalled, result)
+    return trace(DialogsTraceDefinitions.contextEnd, async ({ record }) => {
+      const activeDialogDefinition = this.activeDialog ? this.findDialog(this.activeDialog.id) : undefined
 
-    // Resume parent dialog
-    const instance: DialogInstance<any> = this.activeDialog
-    if (instance) {
-      // Lookup dialog
-      const dialog: Dialog<{}> = this.findDialog(instance.id)
-      if (!dialog) {
-        throw new DialogContextError(
-                    `DialogContext.endDialog(): Can't resume previous dialog. A dialog with an id of '${instance.id}' wasn't found.`,
-                    this
-        )
+      record({
+        activity: this.context.activity,
+        dialogId: this.activeDialog?.id,
+        name: activeDialogDefinition?.constructor.name,
+        reason: DialogReason.endCalled,
+      })
+
+      // End the active dialog
+      await this.endActiveDialog(DialogReason.endCalled, result)
+
+      // Resume parent dialog
+      const instance: DialogInstance<any> = this.activeDialog
+      let turnResult: DialogTurnResult
+      if (instance) {
+        // Lookup dialog
+        const dialog: Dialog<{}> = this.findDialog(instance.id)
+        if (!dialog) {
+          throw new DialogContextError(
+                        `DialogContext.endDialog(): Can't resume previous dialog. A dialog with an id of '${instance.id}' wasn't found.`,
+                        this
+          )
+        }
+
+        // Return result to previous dialog
+        turnResult = await wrapErrors(this, dialog.resumeDialog(this, DialogReason.endCalled, result))
+      } else {
+        // Signal completion
+        turnResult = { status: DialogTurnStatus.complete, result }
       }
 
-      // Return result to previous dialog
-      return wrapErrors(this, dialog.resumeDialog(this, DialogReason.endCalled, result))
-    } else {
-      // Signal completion
-      return { status: DialogTurnStatus.complete, result }
-    }
+      record({ status: turnResult.status })
+      return turnResult
+    })
   }
 
   /**
@@ -524,11 +581,26 @@ export class DialogContext {
      *
      */
   async replaceDialog (dialogId: string, options?: object): Promise<DialogTurnResult> {
-    // End the active dialog
-    await this.endActiveDialog(DialogReason.replaceCalled)
+    return trace(DialogsTraceDefinitions.contextReplace, async ({ record }) => {
+      const activeDialogDefinition = this.activeDialog ? this.findDialog(this.activeDialog.id) : undefined
+      const replacementDialog = this.findDialog(dialogId)
 
-    // Start replacement dialog
-    return this.beginDialog(dialogId, options)
+      record({
+        activity: this.context.activity,
+        dialogId: this.activeDialog?.id,
+        name: activeDialogDefinition?.constructor.name,
+        replacementDialogId: dialogId,
+        replacementName: replacementDialog?.constructor.name,
+      })
+
+      // End the active dialog
+      await this.endActiveDialog(DialogReason.replaceCalled)
+
+      // Start replacement dialog
+      const result = await this.beginDialog(dialogId, options)
+      record({ status: result?.status })
+      return result
+    })
   }
 
   /**

--- a/packages/agents-hosting-dialogs/src/dialogContext.ts
+++ b/packages/agents-hosting-dialogs/src/dialogContext.ts
@@ -471,7 +471,7 @@ export class DialogContext {
         this.context.turnState.set(ACTIVITY_RECEIVED_EMITTED, true)
 
         // Dispatch "activityReceived" event
-        // - This fired from teh leaf and will queue up any interruptions.
+        // - This fired from the leaf and will queue up any interruptions.
         await this.emitEvent(DialogEvents.activityReceived, this.context.activity, true, true)
       }
 

--- a/packages/agents-hosting-dialogs/src/dialogHelper.ts
+++ b/packages/agents-hosting-dialogs/src/dialogHelper.ts
@@ -16,6 +16,7 @@ import { DialogSet } from './dialogSet'
 import { DialogStateManager, DialogStateManagerConfiguration } from './memory'
 import { DialogTurnResult } from './dialogTurnResult'
 import { DialogTurnStatus } from './dialogTurnStatus'
+import { DialogsTraceDefinitions, trace } from './observability'
 
 /**
  * Runs a dialog from a given context and accessor.
@@ -78,45 +79,53 @@ export async function internalRun (
   dialogContext: DialogContext,
   dialogStateManagerConfiguration?: DialogStateManagerConfiguration
 ): Promise<DialogTurnResult> {
-  // map TurnState into root dialog context.services
-  context.turnState.forEach((service, key) => {
-    dialogContext.services.push(key, service)
-  })
+  return trace(DialogsTraceDefinitions.run, async ({ record }) => {
+    record({ activity: context.activity, dialogId })
 
-  const dialogStateManager = new DialogStateManager(dialogContext, dialogStateManagerConfiguration)
+    // map TurnState into root dialog context.services
+    context.turnState.forEach((service, key) => {
+      dialogContext.services.push(key, service)
+    })
 
-  await dialogStateManager.loadAllScopes()
-  dialogContext.context.turnState.push('DialogStateManager', dialogStateManager)
-  let dialogTurnResult: DialogTurnResult = null
+    const dialogStateManager = new DialogStateManager(dialogContext, dialogStateManagerConfiguration)
 
-  // Loop as long as we are getting valid OnError handled we should continue executing the actions for the turn.
-  // NOTE: We loop around this block because each pass through we either complete the turn and break out of the loop
-  // or we have had an exception AND there was an OnError action which captured the error. We need to continue the
-  // turn based on the actions the OnError handler introduced.
-  let endOfTurn = false
-  while (!endOfTurn) {
-    try {
-      dialogTurnResult = await innerRun(context, dialogId, dialogContext)
+    await dialogStateManager.loadAllScopes()
+    dialogContext.context.turnState.push('DialogStateManager', dialogStateManager)
+    let dialogTurnResult: DialogTurnResult = null
+    let attemptCount = 0
 
-      // turn successfully completed, break the loop
-      endOfTurn = true
-    } catch (err) {
-      // fire error event, bubbling from the leaf.
-      const handled = await dialogContext.emitEvent(DialogEvents.error, err, true, true)
+    // Loop as long as we are getting valid OnError handled we should continue executing the actions for the turn.
+    // NOTE: We loop around this block because each pass through we either complete the turn and break out of the loop
+    // or we have had an exception AND there was an OnError action which captured the error. We need to continue the
+    // turn based on the actions the OnError handler introduced.
+    let endOfTurn = false
+    while (!endOfTurn) {
+      attemptCount += 1
+      record({ attemptCount })
+      try {
+        dialogTurnResult = await innerRun(context, dialogId, dialogContext)
+        record({ status: dialogTurnResult?.status })
 
-      if (!handled) {
-        // error was NOT handled, throw the exception and end the turn.
-        // (This will trigger the Adapter.OnError handler and end the entire dialog stack)
-        throw err
+        // turn successfully completed, break the loop
+        endOfTurn = true
+      } catch (err) {
+        // fire error event, bubbling from the leaf.
+        const handled = await dialogContext.emitEvent(DialogEvents.error, err, true, true)
+
+        if (!handled) {
+          // error was NOT handled, throw the exception and end the turn.
+          // (This will trigger the Adapter.OnError handler and end the entire dialog stack)
+          throw err
+        }
       }
     }
-  }
 
-  // save all state scopes to their respective agentState locations.
-  await dialogStateManager.saveAllChanges()
+    // save all state scopes to their respective agentState locations.
+    await dialogStateManager.saveAllChanges()
 
-  // return the redundant result because the DialogManager contract expects it
-  return dialogTurnResult
+    // return the redundant result because the DialogManager contract expects it
+    return dialogTurnResult
+  })
 }
 
 /**

--- a/packages/agents-hosting-dialogs/src/observability/index.ts
+++ b/packages/agents-hosting-dialogs/src/observability/index.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export * from './metrics'
+export * from './traces'
+export { trace } from '@microsoft/agents-telemetry'

--- a/packages/agents-hosting-dialogs/src/observability/metrics.ts
+++ b/packages/agents-hosting-dialogs/src/observability/metrics.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { metric, MetricNames } from '@microsoft/agents-telemetry'
+
+export const DialogsMetrics = {
+  contextCount: metric.counter(MetricNames.DIALOGS_CONTEXT_COUNT, {
+    unit: 'operation',
+    description: 'Total number of dialog context operations'
+  }),
+
+  contextDuration: metric.histogram(MetricNames.DIALOGS_CONTEXT_DURATION, {
+    unit: 'ms',
+    description: 'Duration of dialog context operations in milliseconds'
+  })
+}

--- a/packages/agents-hosting-dialogs/src/observability/metrics.ts
+++ b/packages/agents-hosting-dialogs/src/observability/metrics.ts
@@ -5,7 +5,7 @@ import { metric, MetricNames } from '@microsoft/agents-telemetry'
 
 export const DialogsMetrics = {
   contextCount: metric.counter(MetricNames.DIALOGS_CONTEXT_COUNT, {
-    unit: 'operation',
+    unit: 'operations',
     description: 'Total number of dialog context operations'
   }),
 

--- a/packages/agents-hosting-dialogs/src/observability/traces.ts
+++ b/packages/agents-hosting-dialogs/src/observability/traces.ts
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { SpanNames, trace } from '@microsoft/agents-telemetry'
+import { DialogsMetrics } from './metrics'
+import { Activity } from '@microsoft/agents-activity'
+
+const unknownValue = (value?: string): string => value || 'unknown'
+const defaultActivity = Activity.fromObject({ type: 'unknown' })
+
+export const DialogsTraceDefinitions = {
+  run: trace.define({
+    name: SpanNames.DIALOGS_RUN,
+    record: {
+      dialogId: '',
+      activity: defaultActivity,
+      status: 'unknown',
+      attemptCount: 0,
+    },
+    end ({ span, record }) {
+      span.setAttributes({
+        'dialog.root_id': unknownValue(record.dialogId),
+        'activity.type': unknownValue(record.activity?.type),
+        'activity.channel_id': unknownValue(record.activity?.channelId),
+        'activity.conversation_id': unknownValue(record.activity?.conversation?.id),
+        'dialog.status': unknownValue(record.status),
+        'dialog.attempt_count': record.attemptCount ?? 0,
+      })
+    }
+  }),
+
+  contextBegin: trace.define({
+    name: SpanNames.DIALOGS_CONTEXT_BEGIN,
+    record: {
+      dialogId: '',
+      name: 'unknown',
+      parentId: '',
+      status: 'unknown',
+      activity: defaultActivity,
+    },
+    end ({ span, record, duration }) {
+      const spanAttributes = {
+        'activity.type': unknownValue(record.activity?.type),
+        'activity.conversation_id': unknownValue(record.activity?.conversation?.id),
+        'dialog.id': unknownValue(record.dialogId),
+        'dialog.name': unknownValue(record.name),
+        'dialog.parent_id': unknownValue(record.parentId),
+        'dialog.status': unknownValue(record.status),
+      }
+
+      span.setAttributes(spanAttributes)
+
+      const metricAttributes = {
+        operation: 'begin',
+        'result.status': unknownValue(record.status),
+      }
+
+      DialogsMetrics.contextCount.add(1, metricAttributes)
+      DialogsMetrics.contextDuration.record(duration, metricAttributes)
+    }
+  }),
+
+  contextContinue: trace.define({
+    name: SpanNames.DIALOGS_CONTEXT_CONTINUE,
+    record: {
+      dialogId: '',
+      name: 'unknown',
+      status: 'unknown',
+      activity: defaultActivity,
+    },
+    end ({ span, record, duration }) {
+      const spanAttributes = {
+        'activity.type': unknownValue(record.activity?.type),
+        'activity.conversation_id': unknownValue(record.activity?.conversation?.id),
+        'dialog.id': unknownValue(record.dialogId),
+        'dialog.name': unknownValue(record.name),
+        'dialog.status': unknownValue(record.status),
+      }
+
+      span.setAttributes(spanAttributes)
+
+      const metricAttributes = {
+        operation: 'continue',
+        'result.status': unknownValue(record.status),
+      }
+
+      DialogsMetrics.contextCount.add(1, metricAttributes)
+      DialogsMetrics.contextDuration.record(duration, metricAttributes)
+    }
+  }),
+
+  contextEnd: trace.define({
+    name: SpanNames.DIALOGS_CONTEXT_END,
+    record: {
+      activity: defaultActivity,
+      dialogId: '',
+      name: 'unknown',
+      reason: '',
+      status: 'unknown',
+    },
+    end ({ span, record, duration }) {
+      const spanAttributes = {
+        'activity.type': unknownValue(record.activity?.type),
+        'activity.conversation_id': unknownValue(record.activity?.conversation?.id),
+        'dialog.id': unknownValue(record.dialogId),
+        'dialog.name': unknownValue(record.name),
+        'dialog.reason': unknownValue(record.reason),
+        'dialog.status': unknownValue(record.status),
+      }
+
+      span.setAttributes(spanAttributes)
+
+      const metricAttributes = {
+        operation: 'end',
+        'result.status': unknownValue(record.status),
+        'dialog.reason': unknownValue(record.reason),
+      }
+
+      DialogsMetrics.contextCount.add(1, metricAttributes)
+      DialogsMetrics.contextDuration.record(duration, metricAttributes)
+    }
+  }),
+
+  contextReplace: trace.define({
+    name: SpanNames.DIALOGS_CONTEXT_REPLACE,
+    record: {
+      activity: defaultActivity,
+      dialogId: '',
+      name: 'unknown',
+      replacementDialogId: '',
+      replacementName: 'unknown',
+      status: 'unknown',
+    },
+    end ({ span, record, duration }) {
+      const spanAttributes = {
+        'activity.type': unknownValue(record.activity?.type),
+        'activity.conversation_id': unknownValue(record.activity?.conversation?.id),
+        'dialog.id': unknownValue(record.dialogId),
+        'dialog.name': unknownValue(record.name),
+        'dialog.replacement_id': unknownValue(record.replacementDialogId),
+        'dialog.replacement_name': unknownValue(record.replacementName),
+        'dialog.status': unknownValue(record.status),
+      }
+
+      span.setAttributes(spanAttributes)
+
+      const metricAttributes = {
+        operation: 'replace',
+        'result.status': unknownValue(record.status),
+      }
+
+      DialogsMetrics.contextCount.add(1, metricAttributes)
+      DialogsMetrics.contextDuration.record(duration, metricAttributes)
+    }
+  }),
+
+  contextCancelAll: trace.define({
+    name: SpanNames.DIALOGS_CONTEXT_CANCEL_ALL,
+    record: {
+      activity: defaultActivity,
+      cancelParents: false,
+      dialogId: '',
+      eventName: '',
+      name: 'unknown',
+      status: 'unknown',
+    },
+    end ({ span, record, duration }) {
+      const spanAttributes = {
+        'activity.type': unknownValue(record.activity?.type),
+        'activity.conversation_id': unknownValue(record.activity?.conversation?.id),
+        'dialog.cancel_parents': record.cancelParents,
+        'dialog.event_name': unknownValue(record.eventName),
+        'dialog.id': unknownValue(record.dialogId),
+        'dialog.name': unknownValue(record.name),
+        'dialog.status': unknownValue(record.status),
+      }
+
+      span.setAttributes(spanAttributes)
+
+      const metricAttributes = {
+        operation: 'cancel_all',
+        'result.status': unknownValue(record.status),
+        'dialog.cancel_parents': record.cancelParents,
+      }
+
+      DialogsMetrics.contextCount.add(1, metricAttributes)
+      DialogsMetrics.contextDuration.record(duration, metricAttributes)
+    }
+  }),
+}

--- a/packages/agents-hosting-dialogs/src/observability/traces.ts
+++ b/packages/agents-hosting-dialogs/src/observability/traces.ts
@@ -95,7 +95,6 @@ export const DialogsTraceDefinitions = {
       activity: defaultActivity,
       dialogId: '',
       name: 'unknown',
-      reason: '',
       status: 'unknown',
     },
     end ({ span, record, duration }) {
@@ -104,7 +103,6 @@ export const DialogsTraceDefinitions = {
         'activity.conversation_id': unknownValue(record.activity?.conversation?.id),
         'dialog.id': unknownValue(record.dialogId),
         'dialog.name': unknownValue(record.name),
-        'dialog.reason': unknownValue(record.reason),
         'dialog.status': unknownValue(record.status),
       }
 
@@ -113,7 +111,6 @@ export const DialogsTraceDefinitions = {
       const metricAttributes = {
         operation: 'end',
         'result.status': unknownValue(record.status),
-        'dialog.reason': unknownValue(record.reason),
       }
 
       DialogsMetrics.contextCount.add(1, metricAttributes)

--- a/packages/agents-telemetry/src/observability/constants.ts
+++ b/packages/agents-telemetry/src/observability/constants.ts
@@ -15,6 +15,7 @@ export const SpanCategories = {
   STORAGE: ['STORAGE_'],
   AUTHORIZATION: ['AUTHORIZATION_', 'USER_TOKEN_CLIENT_'],
   AUTHENTICATION: ['AUTHENTICATION_'],
+  DIALOGS: ['DIALOGS_'],
 } as const
 
 /**
@@ -81,6 +82,14 @@ export const SpanNames = {
   // TurnContext
   TURN_SEND_ACTIVITIES: 'agents.turn.send_activities',
 
+  // Dialogs
+  DIALOGS_RUN: 'agents.dialogs.run',
+  DIALOGS_CONTEXT_BEGIN: 'agents.dialogs.context.begin',
+  DIALOGS_CONTEXT_CONTINUE: 'agents.dialogs.context.continue',
+  DIALOGS_CONTEXT_END: 'agents.dialogs.context.end',
+  DIALOGS_CONTEXT_REPLACE: 'agents.dialogs.context.replace',
+  DIALOGS_CONTEXT_CANCEL_ALL: 'agents.dialogs.context.cancel_all',
+
   // Copilot Studio Client
   COPILOT_START_CONVERSATION: 'agents.copilot_client.start_conversation',
   COPILOT_SEND_ACTIVITY: 'agents.copilot_client.send_activity',
@@ -115,6 +124,10 @@ export const MetricNames = {
   TURNS_COUNT: 'agents.turn.count',
   TURNS_ERRORS: 'agents.turn.error.count',
   TURN_DURATION: 'agents.turn.duration',
+
+  // Dialog metrics
+  DIALOGS_CONTEXT_COUNT: 'agents.dialogs.context.count',
+  DIALOGS_CONTEXT_DURATION: 'agents.dialogs.context.duration',
 
   // Storage metrics
   STORAGE_OPERATION_DURATION: 'agents.storage.operation.duration',


### PR DESCRIPTION
Addresses #923

This pull request introduces comprehensive observability (tracing and metrics) to the dialog management system, enabling detailed tracking of dialog operations such as begin, continue, end, replace, and cancel. It adds new trace definitions and metrics, instruments key dialog methods with tracing, and defines new constants for observability. These enhancements will help with debugging, monitoring, and performance analysis of dialog flows.

**Observability Infrastructure**

* Added new observability modules: `metrics.ts`, `traces.ts`, and an index file under `src/observability`, exporting dialog-specific metrics and trace definitions for dialog operations. [[1]](diffhunk://#diff-0600950144254a99d3178b790829611e373826eb3ec5c59eb60d98223b4b7c07R1-R6) [[2]](diffhunk://#diff-a922480eb666c7fb8397967ed2fab451e6472c0a15dff40f962cae535626af2cR1-R16) [[3]](diffhunk://#diff-5f28e3ee6e0ac9c7e9d7801e86bd5e6a86f3e8b8a0bc304a60e7a5679400f298R1-R190)
* Introduced dialog-specific span and metric names in `agents-telemetry` constants to support the new observability features. [[1]](diffhunk://#diff-34794b372b9d5728f46dd1d4427000e1b3400463e010956d6dc9dc2fba477128R18) [[2]](diffhunk://#diff-34794b372b9d5728f46dd1d4427000e1b3400463e010956d6dc9dc2fba477128R85-R92) [[3]](diffhunk://#diff-34794b372b9d5728f46dd1d4427000e1b3400463e010956d6dc9dc2fba477128R128-R131)

**Instrumentation of Dialog Operations**

* Instrumented all major dialog lifecycle methods (`beginDialog`, `continueDialog`, `endDialog`, `replaceDialog`, `cancelAllDialogs`) in `dialogContext.ts` with tracing, capturing key attributes and recording metrics for each operation. [[1]](diffhunk://#diff-254450ccb4a1e5fb7f1a6f9c40ddf9b3b0c955a3859d5e377de90fa23ae8c294R22) [[2]](diffhunk://#diff-254450ccb4a1e5fb7f1a6f9c40ddf9b3b0c955a3859d5e377de90fa23ae8c294R252-R258) [[3]](diffhunk://#diff-254450ccb4a1e5fb7f1a6f9c40ddf9b3b0c955a3859d5e377de90fa23ae8c294R268-R269) [[4]](diffhunk://#diff-254450ccb4a1e5fb7f1a6f9c40ddf9b3b0c955a3859d5e377de90fa23ae8c294L268-R281) [[5]](diffhunk://#diff-254450ccb4a1e5fb7f1a6f9c40ddf9b3b0c955a3859d5e377de90fa23ae8c294R302-R314) [[6]](diffhunk://#diff-254450ccb4a1e5fb7f1a6f9c40ddf9b3b0c955a3859d5e377de90fa23ae8c294L315-R347) [[7]](diffhunk://#diff-254450ccb4a1e5fb7f1a6f9c40ddf9b3b0c955a3859d5e377de90fa23ae8c294R462-R467) [[8]](diffhunk://#diff-254450ccb4a1e5fb7f1a6f9c40ddf9b3b0c955a3859d5e377de90fa23ae8c294R480) [[9]](diffhunk://#diff-254450ccb4a1e5fb7f1a6f9c40ddf9b3b0c955a3859d5e377de90fa23ae8c294R491-R501) [[10]](diffhunk://#diff-254450ccb4a1e5fb7f1a6f9c40ddf9b3b0c955a3859d5e377de90fa23ae8c294R528-R543) [[11]](diffhunk://#diff-254450ccb4a1e5fb7f1a6f9c40ddf9b3b0c955a3859d5e377de90fa23ae8c294L502-R563) [[12]](diffhunk://#diff-254450ccb4a1e5fb7f1a6f9c40ddf9b3b0c955a3859d5e377de90fa23ae8c294R584-R603)

* Instrumented the `internalRun` function in `dialogHelper.ts` to trace the root dialog run operation, including attempt counts and status. [[1]](diffhunk://#diff-eebd59048480f5ff9eb8f1ed3178181f17098fc03f28dd79c1b8bd212d03f6fcR19) [[2]](diffhunk://#diff-eebd59048480f5ff9eb8f1ed3178181f17098fc03f28dd79c1b8bd212d03f6fcR82-R84) [[3]](diffhunk://#diff-eebd59048480f5ff9eb8f1ed3178181f17098fc03f28dd79c1b8bd212d03f6fcR95-R107) [[4]](diffhunk://#diff-eebd59048480f5ff9eb8f1ed3178181f17098fc03f28dd79c1b8bd212d03f6fcR128)

These changes provide a robust foundation for monitoring dialog execution, diagnosing issues, and collecting performance data across the dialog system.

The following image shows a few of the traced scenarios
<img width="2085" height="857" alt="imagen" src="https://github.com/user-attachments/assets/c38bda65-777e-4143-b659-59b3f145b3cd" />
