### PR TITLE
[#1062] Fix top-level await for ESM browser builds in agents-telemetry

### DIFF
--- a/packages/agents-copilotstudio-client/package.json
+++ b/packages/agents-copilotstudio-client/package.json
@@ -24,7 +24,7 @@
     "crypto": "./src/browser/crypto.ts"
   },
   "scripts": {
-    "build:browser": "esbuild --platform=browser --target=es2022 --format=esm --bundle --sourcemap --minify --outfile=dist/src/browser.mjs src/index.ts"
+    "build:browser": "esbuild --platform=browser --target=es2019 --format=esm --bundle --sourcemap --minify --outfile=dist/src/browser.mjs src/index.ts"
   },
   "dependencies": {
     "@microsoft/agents-activity": "file:../agents-activity",

--- a/packages/agents-telemetry/package.json
+++ b/packages/agents-telemetry/package.json
@@ -22,7 +22,7 @@
   "main": "./dist/cjs/src/index.cjs",
   "module": "./dist/esm/src/index.mjs",
   "types": "./dist/esm/src/index.d.mts",
-  "browser": "./dist/esm/src/index.mjs",
+  "browser": "./dist/esm/src/index.cjs",
   "scripts": {
     "clean:esm": "node -e \"require('node:fs').rmSync('dist/esm', { recursive: true, force: true })\"",
     "build:esm": "tsc --project tsconfig.esm.json && node scripts/esm.mjs"
@@ -56,7 +56,7 @@
     ".": {
       "import": {
         "types": "./dist/esm/src/index.d.mts",
-        "browser": "./dist/esm/src/index.mjs",
+        "browser": "./dist/esm/src/index.cjs",
         "default": "./dist/esm/src/index.mjs"
       },
       "require": {

--- a/packages/agents-telemetry/tsconfig.esm.json
+++ b/packages/agents-telemetry/tsconfig.esm.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
+  "exclude": [],
   "compilerOptions": {
     "outDir": "dist/esm",
     "composite": false,

--- a/packages/agents-telemetry/tsconfig.esm.json
+++ b/packages/agents-telemetry/tsconfig.esm.json
@@ -1,8 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": [
-    "src/**/*.cts"
-  ],
   "compilerOptions": {
     "outDir": "dist/esm",
     "composite": false,


### PR DESCRIPTION
Fixes #1062

This pull request makes adjustments to the build targets and output formats for the `agents-copilotstudio-client` and `agents-telemetry` packages. The main focus is on improving compatibility by lowering the browser target for the client and aligning the browser entry points to use CommonJS builds in the telemetry package.

Build configuration updates:

* Lowered the browser build target from ES2022 to ES2019 in the `build:browser` script of `agents-copilotstudio-client/package.json` to increase compatibility with older browsers.

Browser entry point changes in telemetry package:

* Changed the `browser` field in `agents-telemetry/package.json` to point to the CommonJS build (`index.cjs`) instead of the ESM build (`index.mjs`) for better compatibility.
* Updated the exports map in `agents-telemetry/package.json` so the `browser` import also points to the CommonJS build.

TypeScript configuration:

* Removed the explicit exclusion of `.cts` files from the ESM TypeScript configuration in `agents-telemetry/tsconfig.esm.json`, potentially allowing for a broader set of source files to be included in the ESM build.

**Testing**
The following image shows the bundle for browser working.
<img width="1453" height="944" alt="image" src="https://github.com/user-attachments/assets/93f13b9e-4040-48e1-8e98-3738a122d3b2" />
