### PR TITLE
[#1052] Fix browser build

### DIFF
--- a/packages/agents-telemetry/package.json
+++ b/packages/agents-telemetry/package.json
@@ -22,7 +22,7 @@
   "main": "./dist/cjs/src/index.cjs",
   "module": "./dist/esm/src/index.mjs",
   "types": "./dist/esm/src/index.d.mts",
-  "browser": "./dist/esm/src/index.cjs",
+  "browser": "./dist/cjs/src/index.cjs",
   "scripts": {
     "clean:esm": "node -e \"require('node:fs').rmSync('dist/esm', { recursive: true, force: true })\"",
     "build:esm": "tsc --project tsconfig.esm.json && node scripts/esm.mjs"
@@ -56,7 +56,7 @@
     ".": {
       "import": {
         "types": "./dist/esm/src/index.d.mts",
-        "browser": "./dist/esm/src/index.cjs",
+        "browser": "./dist/cjs/src/index.cjs",
         "default": "./dist/esm/src/index.mjs"
       },
       "require": {


### PR DESCRIPTION
This pull request updates the `browser` entry points in the `packages/agents-telemetry/package.json` file to ensure that the correct CommonJS build is used for browser environments. This resolves a misconfiguration where the ESM build was previously referenced for browsers.

**Build and packaging fixes:**

* Changed the `browser` field in the package root to point to `./dist/cjs/src/index.cjs` instead of the ESM build, ensuring the correct CommonJS bundle is used in browser environments.
* Updated the `exports` field's `import.browser` path to use the CommonJS build (`./dist/cjs/src/index.cjs`) for browser imports, aligning with the main `browser` field and fixing potential module resolution issues.

## Testing
Samples working after the changes
<img width="2423" height="874" alt="image" src="https://github.com/user-attachments/assets/7651e6e1-ac40-404c-ae3c-720841556788" />
<img width="2446" height="896" alt="image" src="https://github.com/user-attachments/assets/5f6399e9-ace6-4f18-bff1-aed47727a805" />
