### PR TITLE
Bump axios version to 1.15.1

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -22,7 +22,11 @@
   "workspaces": {
     // Root
     ".": {
-      "project": ["*.{js,mjs,ts}"]
+      "project": ["*.{js,mjs,ts}"],
+      "ignoreDependencies": [
+        // Samples are built from the root tsconfig, but knip does not model them as a root package.
+        "axios"
+      ]
     },
 
     // Packages

--- a/package-lock.json
+++ b/package-lock.json
@@ -2710,15 +2710,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/axios": {
-      "version": "1.15.0",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -7746,7 +7737,7 @@
         "@azure/msal-node": "5.0.6",
         "@microsoft/agents-activity": "file:../agents-activity",
         "@microsoft/agents-telemetry": "file:../agents-telemetry",
-        "axios": "1.15.0",
+        "axios": "1.15.1",
         "jsonwebtoken": "9.0.3",
         "jwks-rsa": "4.0.1",
         "object-path": "0.11.8",
@@ -7799,11 +7790,22 @@
       "dependencies": {
         "@microsoft/agents-activity": "file:../agents-activity",
         "@microsoft/agents-hosting": "file:../agents-hosting",
-        "axios": "1.15.0",
+        "axios": "1.15.1",
         "zod": "3.25.75"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "packages/agents-hosting-extensions-teams/node_modules/axios": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "packages/agents-hosting-storage-blob": {
@@ -7834,6 +7836,17 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "packages/agents-hosting/node_modules/axios": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "packages/agents-telemetry": {
@@ -7996,8 +8009,19 @@
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/microsoft-graph-client": "3.0.7",
         "adaptivecards-templating": "2.3.1",
-        "axios": "1.15.0",
+        "axios": "1.15.1",
         "express": "5.2.1"
+      }
+    },
+    "test-agents/web-chat/node_modules/axios": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7509,6 +7509,19 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "dev": true,
@@ -7715,19 +7728,6 @@
         "node": ">=20.0.0"
       }
     },
-    "packages/agents-activity/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "packages/agents-copilotstudio-client": {
       "name": "@microsoft/agents-copilotstudio-client",
       "version": "0.1.0",
@@ -7743,19 +7743,6 @@
         "node": ">=20.0.0"
       }
     },
-    "packages/agents-copilotstudio-client/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "packages/agents-hosting": {
       "name": "@microsoft/agents-hosting",
       "version": "0.1.0",
@@ -7769,6 +7756,7 @@
         "jsonwebtoken": "9.0.3",
         "jwks-rsa": "4.0.1",
         "object-path": "0.11.8",
+        "uuid": "11.1.1",
         "zod": "3.25.75"
       },
       "devDependencies": {
@@ -7793,6 +7781,7 @@
         "@types/lodash": "4.17.24",
         "dependency-graph": "1.0.0",
         "globalize": "1.7.1",
+        "uuid": "11.1.1",
         "zod": "3.25.75"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1313,6 +1313,18 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -3967,9 +3979,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
+      "integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
       "funding": [
         {
           "type": "github",
@@ -3982,9 +3994,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
-      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -3993,9 +4005,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -6193,9 +6206,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -7097,9 +7110,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",
@@ -7496,17 +7509,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "dev": true,
@@ -7706,11 +7708,24 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "uuid": "11.1.0",
+        "uuid": "11.1.1",
         "zod": "3.25.75"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "packages/agents-activity/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "packages/agents-copilotstudio-client": {
@@ -7722,10 +7737,23 @@
         "@microsoft/agents-telemetry": "file:../agents-telemetry",
         "eventsource-client": "1.2.0",
         "rxjs": "7.8.2",
-        "uuid": "11.1.0"
+        "uuid": "11.1.1"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "packages/agents-copilotstudio-client/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "packages/agents-hosting": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/node": "25.6.0",
         "@types/sinon": "21.0.0",
         "@types/uuid": "10.0.0",
+        "axios": "1.15.1",
         "esbuild": "0.27.3",
         "eslint": "9.39.2",
         "knip": "5.86.0",
@@ -2720,6 +2721,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -7814,17 +7826,6 @@
         "node": ">=20.0.0"
       }
     },
-    "packages/agents-hosting-extensions-teams/node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
     "packages/agents-hosting-storage-blob": {
       "name": "@microsoft/agents-hosting-storage-blob",
       "version": "0.1.0",
@@ -7853,17 +7854,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "packages/agents-hosting/node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
       }
     },
     "packages/agents-telemetry": {
@@ -8028,17 +8018,6 @@
         "adaptivecards-templating": "2.3.1",
         "axios": "1.15.1",
         "express": "5.2.1"
-      }
-    },
-    "test-agents/web-chat/node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/node": "25.6.0",
     "@types/sinon": "21.0.0",
     "@types/uuid": "10.0.0",
+    "axios": "1.15.1",
     "esbuild": "0.27.3",
     "eslint": "9.39.2",
     "knip": "5.86.0",

--- a/package.json
+++ b/package.json
@@ -69,11 +69,11 @@
   "overrides": {
     "adaptivecards-templating": {
       "adaptive-expressions": {
-        "fast-xml-parser": "5.5.7"
+        "fast-xml-parser": "5.7.0"
       }
     }
   },
   "overridesComments": {
-    "adaptivecards-templating/adaptive-expressions/fast-xml-parser": "Override to 5.5.7 because adaptive-expressions pulls vulnerable 4.5.3 (test-agents/web-chat)"
+    "adaptivecards-templating/adaptive-expressions/fast-xml-parser": "Override to 5.7.0 because adaptive-expressions pulls vulnerable 4.5.3 (test-agents/web-chat)"
   }
 }

--- a/packages/agents-activity/package.json
+++ b/packages/agents-activity/package.json
@@ -19,7 +19,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "dependencies": {
-    "uuid": "11.1.0",
+    "uuid": "11.1.1",
     "zod": "3.25.75"
   },
   "license": "MIT",

--- a/packages/agents-copilotstudio-client/package.json
+++ b/packages/agents-copilotstudio-client/package.json
@@ -31,7 +31,7 @@
     "@microsoft/agents-telemetry": "file:../agents-telemetry",
     "eventsource-client": "1.2.0",
     "rxjs": "7.8.2",
-    "uuid": "11.1.0"
+    "uuid": "11.1.1"
   },
   "license": "MIT",
   "files": [

--- a/packages/agents-hosting-dialogs/package.json
+++ b/packages/agents-hosting-dialogs/package.json
@@ -25,6 +25,7 @@
     "@microsoft/recognizers-text-date-time": "1.3.2",
     "@microsoft/recognizers-text-choice": "1.3.1",
     "globalize": "1.7.1",
+    "uuid": "11.1.1",
     "zod": "3.25.75",
     "@microsoft/agents-telemetry": "file:../agents-telemetry"
   },

--- a/packages/agents-hosting-extensions-teams/package.json
+++ b/packages/agents-hosting-extensions-teams/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@microsoft/agents-hosting": "file:../agents-hosting",
     "@microsoft/agents-activity": "file:../agents-activity",
-    "axios": "1.15.0",
+    "axios": "1.15.1",
     "zod": "3.25.75"
   },
   "license": "MIT",

--- a/packages/agents-hosting/package.json
+++ b/packages/agents-hosting/package.json
@@ -27,6 +27,7 @@
     "jsonwebtoken": "9.0.3",
     "jwks-rsa": "4.0.1",
     "object-path": "0.11.8",
+    "uuid": "11.1.1",
     "zod": "3.25.75"
   },
   "license": "MIT",

--- a/packages/agents-hosting/package.json
+++ b/packages/agents-hosting/package.json
@@ -23,7 +23,7 @@
     "@azure/msal-node": "5.0.6",
     "@microsoft/agents-activity": "file:../agents-activity",
     "@microsoft/agents-telemetry": "file:../agents-telemetry",
-    "axios": "1.15.0",
+    "axios": "1.15.1",
     "jsonwebtoken": "9.0.3",
     "jwks-rsa": "4.0.1",
     "object-path": "0.11.8",

--- a/packages/agents-hosting/src/app/teamsAttachmentDownloader.ts
+++ b/packages/agents-hosting/src/app/teamsAttachmentDownloader.ts
@@ -72,7 +72,8 @@ export class M365AttachmentDownloader<TState extends TurnState = TurnState> impl
         const response = await this._httpClient.get(downloadUrl, { responseType: 'arraybuffer' })
 
         const content = Buffer.from(response.data, 'binary')
-        const contentType = response.headers['content-type'] || 'application/octet-stream'
+        const contentTypeHeader = response.headers['content-type']
+        const contentType = typeof contentTypeHeader === 'string' ? contentTypeHeader : 'application/octet-stream'
         inputFile = { content, contentType, contentUrl: attachment.contentUrl }
       } catch (error) {
         logger.error(`Failed to download Teams attachment: ${error}`)

--- a/test-agents/web-chat/package.json
+++ b/test-agents/web-chat/package.json
@@ -19,7 +19,7 @@
     "@microsoft/agents-activity": "file:../../packages/agents-activity",
     "@microsoft/microsoft-graph-client": "3.0.7",
     "adaptivecards-templating": "2.3.1",
-    "axios": "1.15.0",
+    "axios": "1.15.1",
     "express": "5.2.1"
   }
 }


### PR DESCRIPTION
## Description
This PR updates the axios dependency to address security vulnerabilities.
Additionally, it upgrades the `uuid`, and `fast-xml-parser` packages to fix moderate vulnerabilities.

### Detailed Changes
* Upgraded `axios` from `1.15.0` to `1.15.1` in `packages/agents-hosting/package.json`, `packages/agents-hosting-extensions-teams/package.json`, and `test-agents/web-chat/package.json` to address security and bug fixes. [[1]](diffhunk://#diff-f5c6b51b6c423a144c6d85766dba1e080ee00a18ed060be6fc8925205dec71fbL26-R26) [[2]](diffhunk://#diff-9cbd83fba18b04750e17f3f698bb7de3ce59eec89987b1f5bee1d9c8a253d181L24-R24) [[3]](diffhunk://#diff-6dccdb0db0849f2e8c9b749caa0b68ee85f9f164e4b9eee4933aa3a9b3b14cd4L22-R22)
* Updated `uuid` from `11.1.0` to `11.1.1` in `packages/agents-activity/package.json` and `packages/agents-copilotstudio-client/package.json` for improved stability and bug fixes. [[1]](diffhunk://#diff-4f86354aaeecf8073a43fba31cdd64ee1f1b619ed5d99459609fb3c4b0555185L22-R22) [[2]](diffhunk://#diff-a17805e5644127cec984440806882efa518355dde1f51b8384c901454a4ed315L34-R34)
* Increased `fast-xml-parser` override version from `5.5.7` to `5.7.0` in the root `package.json` to mitigate vulnerabilities pulled in by `adaptive-expressions`.
* Updated the header handling in teamsAttachmentDownloader.
* Added missing uuid and axios references in agents-hosting and root package.json.

## Testing
This image shows the TeamsAttachmentDownloader feature working after the change (axios).
<img width="1595" height="707" alt="image" src="https://github.com/user-attachments/assets/ab05b4b4-3f92-4740-97d7-7420e79a0701" />
