### PR TITLE
Remove lodash dependency and refactor AdditionalProperties handling in Recognizer class

### DIFF
--- a/packages/agents-hosting-dialogs/package.json
+++ b/packages/agents-hosting-dialogs/package.json
@@ -23,7 +23,6 @@
     "@microsoft/recognizers-text-date-time": "1.3.2",
     "@microsoft/recognizers-text-number": "1.3.1",
     "@microsoft/recognizers-text-suite": "1.3.1",
-    "@types/lodash": "4.17.24",
     "dependency-graph": "1.0.0",
     "globalize": "1.7.1",
     "zod": "3.25.75"

--- a/packages/agents-hosting-dialogs/src/recognizer.ts
+++ b/packages/agents-hosting-dialogs/src/recognizer.ts
@@ -6,7 +6,6 @@ import { Activity, ExceptionHelper } from '@microsoft/agents-activity'
 import { Errors } from './errorHelper'
 import { Configurable } from './configurable'
 import { DialogContext } from './dialogContext'
-import omit from 'lodash/omit'
 import { RecognizerResult, getTopScoringIntent } from './recognizerResult'
 
 /**
@@ -133,9 +132,7 @@ export class Recognizer extends Configurable implements RecognizerConfiguration 
       TopIntentScore: intents.length > 0 ? score.toString() : '',
       Intents: intents.length > 0 ? JSON.stringify(recognizerResult.intents) : '',
       Entities: recognizerResult.entities ? JSON.stringify(recognizerResult.entities) : '',
-      AdditionalProperties: JSON.stringify(
-        omit(recognizerResult, ['text', 'alteredText', 'intents', 'entities'])
-      ),
+      AdditionalProperties: this.stringifyAdditionalPropertiesOfRecognizerResult(recognizerResult),
     }
 
     if (telemetryProperties) {

--- a/packages/agents-hosting-dialogs/src/recognizer.ts
+++ b/packages/agents-hosting-dialogs/src/recognizer.ts
@@ -132,7 +132,7 @@ export class Recognizer extends Configurable implements RecognizerConfiguration 
       TopIntentScore: intents.length > 0 ? score.toString() : '',
       Intents: intents.length > 0 ? JSON.stringify(recognizerResult.intents) : '',
       Entities: recognizerResult.entities ? JSON.stringify(recognizerResult.entities) : '',
-      AdditionalProperties: this.stringifyAdditionalPropertiesOfRecognizerResult(recognizerResult),
+      AdditionalProperties: this.stringifyAdditionalPropertiesOfRecognizerResult(recognizerResult) || '{}',
     }
 
     if (telemetryProperties) {
@@ -145,11 +145,10 @@ export class Recognizer extends Configurable implements RecognizerConfiguration 
   protected stringifyAdditionalPropertiesOfRecognizerResult (recognizerResult: RecognizerResult): string {
     const generalProperties = new Set(['text', 'alteredText', 'intents', 'entities'])
     const additionalProperties: { [key: string]: string } = {}
-    for (const key in recognizerResult) {
-      if (!generalProperties.has(key)) {
-        additionalProperties[key] = recognizerResult[key]
-      }
-    }
+    Object.keys(recognizerResult).filter(key => !generalProperties.has(key)).forEach(key => {
+      additionalProperties[key] = recognizerResult[key]
+    })
+
     return Object.keys(additionalProperties).length > 0 ? JSON.stringify(additionalProperties) : ''
   }
 }


### PR DESCRIPTION
This pull request primarily removes the dependency on `lodash` by eliminating its usage in the `Recognizer` class. Instead, an existing method handles additional properties in recognizer results. This simplifies dependencies and internal logic.

**Dependency cleanup:**

* Removed `@types/lodash` from `package.json`, reducing external dependencies.

**Code refactoring:**

* Removed the import of `omit` from `lodash` in `recognizer.ts`.
* Replaced the use of `omit` for extracting additional properties in the `Recognizer` class with the existing method `stringifyAdditionalPropertiesOfRecognizerResult`, improving maintainability and removing the need for an external utility.