### PR TITLE
Update slack error range to avoid overlapping with blobs errors

### DIFF
--- a/packages/agents-hosting-extensions-slack/src/errorHelper.ts
+++ b/packages/agents-hosting-extensions-slack/src/errorHelper.ts
@@ -5,23 +5,23 @@ import type { AgentErrorDefinition } from '@microsoft/agents-activity'
 
 /**
  * Error definitions for the Slack Extensions system.
- * Error codes start at -160000.
+ * Error codes start at -170000.
  */
 export const Errors: { [key: string]: AgentErrorDefinition } = {
   SlackApiError: {
-    code: -160000,
+    code: -170000,
     description: 'Slack API call failed: {error}',
   },
   SlackApiHttpError: {
-    code: -160001,
+    code: -170001,
     description: 'Slack API HTTP request failed with status {status}',
   },
   SlackApiTokenMissing: {
-    code: -160002,
+    code: -170002,
     description: 'No Slack API token available. Set ApiToken in channel data or SLACK_TOKEN environment variable.',
   },
   SlackStreamNotStarted: {
-    code: -160003,
+    code: -170003,
     description: 'SlackStream.start() must be called before append() or stop().',
   },
 }

--- a/packages/agents-hosting-extensions-slack/test/api/slackApi.test.ts
+++ b/packages/agents-hosting-extensions-slack/test/api/slackApi.test.ts
@@ -59,7 +59,7 @@ describe('SlackApi', () => {
     await assert.rejects(
       () => api.call('chat.postMessage', {}),
       (err: Error) => {
-        assert.ok(err.message.includes('-160001'))
+        assert.ok(err.message.includes('-170001'))
         return true
       }
     )
@@ -72,7 +72,7 @@ describe('SlackApi', () => {
     await assert.rejects(
       () => api.call('chat.postMessage', {}),
       (err: Error) => {
-        assert.ok(err.message.includes('-160000'))
+        assert.ok(err.message.includes('-170000'))
         return true
       }
     )

--- a/packages/agents-hosting-extensions-slack/test/api/slackStream.test.ts
+++ b/packages/agents-hosting-extensions-slack/test/api/slackStream.test.ts
@@ -106,7 +106,7 @@ describe('SlackStream', () => {
   it('append() throws when start() not called', async () => {
     const stream = new SlackStream(api, 'C123', '111.222')
     await assert.rejects(() => stream.append('ignored'), (err: Error) => {
-      assert.ok(err.message.includes('-160003'))
+      assert.ok(err.message.includes('-170003'))
       return true
     })
     assert.equal(callStub.callCount, 0)
@@ -115,7 +115,7 @@ describe('SlackStream', () => {
   it('stop() throws when start() not called', async () => {
     const stream = new SlackStream(api, 'C123', '111.222')
     await assert.rejects(() => stream.stop('ignored'), (err: Error) => {
-      assert.ok(err.message.includes('-160003'))
+      assert.ok(err.message.includes('-170003'))
       return true
     })
     assert.equal(callStub.callCount, 0)

--- a/packages/agents-hosting-extensions-slack/test/slackAgentExtension.test.ts
+++ b/packages/agents-hosting-extensions-slack/test/slackAgentExtension.test.ts
@@ -158,7 +158,7 @@ describe('SlackAgentExtension', () => {
       assert.throws(
         () => ext.createStream(ctx),
         (err: Error) => {
-          assert.ok(err.message.includes('-160002'))
+          assert.ok(err.message.includes('-170002'))
           return true
         }
       )


### PR DESCRIPTION
## Description
This pull request updates the error code range for Slack Extensions from the -160000 range to the -170000  to avoid conflicts with the errors defined in Blob Storage. All corresponding unit tests have been updated to match the new codes.

**Error code range update:**

* Updated all error codes in the `Errors` object in `errorHelper.ts` from the -160000 range to the -170000 range.

**Test updates to match new error codes:**

* Updated error code assertions in `slackApi.test.ts` to check for the new -170000 and -170001 codes instead of the previous -160000 and -160001 codes. [[1]](diffhunk://#diff-44cb5461cba72dded80bc391610b2edf56c415a14f6697e24b4e2adb0673ebc2L62-R62) [[2]](diffhunk://#diff-44cb5461cba72dded80bc391610b2edf56c415a14f6697e24b4e2adb0673ebc2L75-R75)
* Updated error code assertions in `slackStream.test.ts` to check for the new -170003 code instead of -160003. [[1]](diffhunk://#diff-7c73d592c9787ae62c87a638e72112e042ea7236d757da36af4ce2c938bdbe13L109-R109) [[2]](diffhunk://#diff-7c73d592c9787ae62c87a638e72112e042ea7236d757da36af4ce2c938bdbe13L118-R118)
* Updated error code assertion in `slackAgentExtension.test.ts` to check for the new -170002 code instead of -160002.

## Testing
This image shows the slack tests passing after the changes.
<img width="520" height="336" alt="image" src="https://github.com/user-attachments/assets/299afd1b-9b78-49d4-9091-78d362bdc1f8" />