### PR TITLE
fix: update error codes to fix some conflicts

### DIFF
--- a/packages/agents-hosting/src/errorHelper.ts
+++ b/packages/agents-hosting/src/errorHelper.ts
@@ -1012,7 +1012,7 @@ export const Errors: { [key: string]: AgentErrorDefinition } = {
   },
 
   // ============================================================================
-  // Hosting / Web layer errors (-120800 to -120840)
+  // Hosting / Web layer errors (-120910 to -120940)
   // ============================================================================
 
   /**
@@ -1020,7 +1020,7 @@ export const Errors: { [key: string]: AgentErrorDefinition } = {
    * Indicates the hosting layer (e.g. express.json() or Fastify's JSON parser) was not configured.
    */
   MissingRequestBody: {
-    code: -120800,
+    code: -120910,
     description: '`request.body` parameter required; ensure your hosting layer parses JSON request bodies before invoking the adapter (e.g., express.json() with Express or Fastify\'s built-in JSON parser).'
   },
 
@@ -1028,7 +1028,7 @@ export const Errors: { [key: string]: AgentErrorDefinition } = {
    * Error thrown by verifyToken when the provided JWT cannot be decoded.
    */
   InvalidJwtToken: {
-    code: -120810,
+    code: -120920,
     description: 'invalid token'
   },
 
@@ -1036,7 +1036,7 @@ export const Errors: { [key: string]: AgentErrorDefinition } = {
    * Error thrown by verifyToken when the token audience does not match any configured connection clientId.
    */
   JwtAudienceMismatch: {
-    code: -120820,
+    code: -120930,
     description: 'Audience mismatch'
   },
 

--- a/packages/agents-hosting/test/hosting/adapter/cloudAdapter.webresponse.test.ts
+++ b/packages/agents-hosting/test/hosting/adapter/cloudAdapter.webresponse.test.ts
@@ -79,7 +79,7 @@ describe('CloudAdapter.process (WebResponse contract)', () => {
       adapter.process(req, res, async () => {}),
       (err: any) => {
         assert.ok(err instanceof TypeError, 'should be a TypeError')
-        assert.strictEqual(err.code, -120800, 'should expose MissingRequestBody AgentError code')
+        assert.strictEqual(err.code, -120910, 'should expose MissingRequestBody AgentError code')
         assert.ok(typeof err.helpLink === 'string' && err.helpLink.length > 0, 'should expose helpLink')
         assert.ok(/request\.body/.test(err.message), 'message should reference request.body')
         return true


### PR DESCRIPTION
This pull request updates the error code ranges for hosting and web layer errors in the `agents-hosting` package to avoid conflicts and ensure consistency. The main changes include shifting the error codes for several hosting-related errors and updating corresponding test assertions.

**Error code range update:**

* [`packages/agents-hosting/src/errorHelper.ts`](diffhunk://#diff-a99d0b88336dd114b0573b8c64cca81a0e18eef6206caead4f18258cff0b7d94L1015-R1039): Changed the error code range for hosting/web layer errors from `-120800`–`-120840` to `-120910`–`-120940`, and updated the codes for `MissingRequestBody`, `InvalidJwtToken`, and `JwtAudienceMismatch` errors accordingly.

**Test updates:**

* [`packages/agents-hosting/test/hosting/adapter/cloudAdapter.webresponse.test.ts`](diffhunk://#diff-1dde8adcd6294f08c7de3b9b03e99c61327222dff1b76147738b5d74d9eb7f9fL82-R82): Updated the test for `MissingRequestBody` to assert the new error code (`-120910` instead of `-120800`).