### PR TITLE
feat: add streaming timeout handling and notifications in StreamingResponse

### DIFF
--- a/compat/baseline/agents-hosting.api.md
+++ b/compat/baseline/agents-hosting.api.md
@@ -1371,6 +1371,7 @@ export class StreamingResponse {
     queueInformativeUpdate(text: string): void;
     queueTextChunk(text: string, citations?: Citation[]): void;
     reset(): Promise<void>;
+    sendStreamTimedOutNotification(message: string): Promise<boolean>;
     setAttachments(attachments: Attachment[]): void;
     setCitations(citations: Citation[]): void;
     setDelayInMs(delayInMs: number): void;
@@ -1380,6 +1381,8 @@ export class StreamingResponse {
     setGeneratedByAILabel(enableGeneratedByAILabel: boolean): void;
     setSensitivityLabel(sensitivityLabel: SensitivityUsageInfo): void;
     get streamId(): string | undefined;
+    get streamingTakingTooLongMessage(): string;
+    set streamingTakingTooLongMessage(message: string);
     get updatesSent(): number;
 }
 

--- a/packages/agents-hosting/src/app/streaming/streamingResponse.ts
+++ b/packages/agents-hosting/src/app/streaming/streamingResponse.ts
@@ -409,9 +409,12 @@ export class StreamingResponse {
    * @returns Whether the streaming response was stopped.
    */
   public async sendStreamTimedOutNotification (message: string): Promise<boolean> {
-    if (this._ended) {
+    if (this._ended || this._canceled || !this.isStreamingChannel) {
       return false
     }
+
+    // Ensure any in-flight queued sends complete before we send the timeout notification.
+    await this.waitForQueue()
 
     await this.sendActivity(this.createStreamStoppedMessage(message))
     this._streamTimeoutNotificationSent = true
@@ -629,7 +632,7 @@ export class StreamingResponse {
       if (!this._streamId) {
         this._streamId = response?.id
       }
-      if (activity.entities?.some(entity => entity.streamType === 'informative')) {
+      if (this.isM365Copilot() && this.isStreamingChannel && !this._ended) {
         this.scheduleKeepAlive()
       }
       await new Promise((resolve) => setTimeout(resolve, this.delayInMs))
@@ -713,8 +716,7 @@ export class StreamingResponse {
   /**
    * Finalizes an M365 Copilot stream that reached the channel duration limit.
    */
-  private async handleM365StreamTimeout (): Promise<void> {
-    if (this._ended || !this.isStreamingChannel || !this.isM365Copilot()) {
+    if (this._ended || this._canceled || !this.isStreamingChannel || !this.isM365Copilot()) {
       return
     }
 

--- a/packages/agents-hosting/src/app/streaming/streamingResponse.ts
+++ b/packages/agents-hosting/src/app/streaming/streamingResponse.ts
@@ -11,6 +11,10 @@ import { debug } from '@microsoft/agents-telemetry'
 import { Errors } from '../../errorHelper'
 
 const logger = debug('agents:streamingResponse')
+const teamsStreamTimedOut = 'Content stream finished due to exceeded streaming time.'
+const defaultStreamingTakingTooLongMessage = 'The response is taking longer than expected. Please wait while we continue to generate the response.'
+const m365StreamingTimeoutMs = 105000
+const m365WorkingNoticeIntervalMs = 35000
 
 /**
  * Results for streaming response operations.
@@ -57,6 +61,13 @@ export class StreamingResponse {
   private _finalMessage?: Activity
   private _canceled = false
   private _userCanceled = false
+  private _streamTimedOut = false
+  private _streamTimeoutNotificationSent = false
+  private _lastInformationalMessageSent = ''
+  private _streamStartedAt?: number
+  private _keepAliveTimer?: ReturnType<typeof setTimeout>
+  private _streamTimeoutTimer?: ReturnType<typeof setTimeout>
+  private _streamingTakingTooLongMessage = defaultStreamingTakingTooLongMessage
 
   // Queue for outgoing activities
   private _queue: Array<() => Activity> = []
@@ -128,11 +139,29 @@ export class StreamingResponse {
   }
 
   /**
+   * Gets the message sent when streaming takes longer than the channel allows.
+   */
+  public get streamingTakingTooLongMessage (): string {
+    return this._streamingTakingTooLongMessage
+  }
+
+  /**
+   * Sets the message sent when streaming takes longer than the channel allows.
+   */
+  public set streamingTakingTooLongMessage (message: string) {
+    this._streamingTakingTooLongMessage = message
+  }
+
+  /**
    * Queues an informative update to be sent to the client.
    *
    * @param {string} text Text of the update to send.
    */
   public queueInformativeUpdate (text: string): void {
+    if (this.isM365Copilot()) {
+      this._lastInformationalMessageSent = text
+    }
+
     if (!this.isStreamingChannel || !text.trim() || this._canceled) {
       return
     }
@@ -203,9 +232,19 @@ export class StreamingResponse {
 
     // Queue final message
     this._ended = true
+    this.clearStreamTimers()
 
     if (!this.isStreamingChannel) {
-      await this.sendActivity(this.createFinalMessage())
+      if (this._streamTimeoutNotificationSent && !this._message && !this._finalMessage && !this._attachments?.length) {
+        return StreamingResponseResult.Success
+      }
+
+      const finalMessage = this.createFinalMessage()
+      if (this._streamTimedOut) {
+        await this.updateActivity(finalMessage)
+      } else {
+        await this.sendActivity(finalMessage)
+      }
       return StreamingResponseResult.Success
     }
 
@@ -223,6 +262,7 @@ export class StreamingResponse {
    */
   public async reset () : Promise<void> {
     await this.waitForQueue()
+    this.clearStreamTimers()
 
     this._queueSync = undefined
     this._queue = []
@@ -230,6 +270,10 @@ export class StreamingResponse {
     this._ended = false
     this._canceled = false
     this._userCanceled = false
+    this._streamTimedOut = false
+    this._streamTimeoutNotificationSent = false
+    this._lastInformationalMessageSent = ''
+    this._streamStartedAt = undefined
     this._message = ''
     this._nextSequence = 1
     this._streamId = undefined
@@ -359,6 +403,26 @@ export class StreamingResponse {
   }
 
   /**
+   * Ends the streaming portion of a response while allowing the underlying operation to continue.
+   *
+   * @param message Message sent to notify the user that streaming has stopped.
+   * @returns Whether the streaming response was stopped.
+   */
+  public async sendStreamTimedOutNotification (message: string): Promise<boolean> {
+    if (this._ended) {
+      return false
+    }
+
+    await this.sendActivity(this.createStreamStoppedMessage(message))
+    this._streamTimeoutNotificationSent = true
+    this._isStreamingChannel = false
+    this._queue = []
+    this._chunkQueued = false
+    this.clearStreamTimers()
+    return true
+  }
+
+  /**
    * Waits for the outgoing activity queue to be empty.
    *
    * @returns {Promise<void>} - A promise representing the async operation.
@@ -446,11 +510,67 @@ export class StreamingResponse {
     activity.attachments = this._attachments
     this._nextSequence++ // Increment sequence for final message, even if not streaming.
 
+    if (this._streamTimedOut && this._streamId) {
+      activity.id = this._streamId
+    }
+
     if (this.isStreamingChannel) {
       activity.entities.push({
         type: 'streaminfo',
         streamType: 'final',
         streamSequence: this._nextSequence
+      })
+    }
+
+    return activity
+  }
+
+  /**
+   * Creates the final streaming notification used when streaming stops but processing continues.
+   */
+  private createStreamStoppedMessage (message: string): Activity {
+    return Activity.fromObject({
+      type: 'message',
+      text: message || 'No text was streamed',
+      entities: [{
+        type: 'streaminfo',
+        streamType: 'final',
+        streamResult: this._message ? 'success' : 'error',
+        streamSequence: this._nextSequence++
+      }]
+    })
+  }
+
+  /**
+   * Creates a checkpoint or final notification for a channel streaming timeout.
+   */
+  private createStreamTimedOutMessage (addStreamFinal = false): Activity {
+    const text = this._message
+      ? `${this._message}\n\n${this.streamingTakingTooLongMessage}\n`
+      : this.streamingTakingTooLongMessage
+    const activity = Activity.fromObject({
+      type: addStreamFinal ? 'message' : (this.isM365Copilot() ? 'typing' : 'message'),
+      text,
+      entities: []
+    })
+
+    if (this._streamId) {
+      activity.id = this._streamId
+    }
+
+    if (addStreamFinal) {
+      activity.entities!.push({
+        type: 'streaminfo',
+        streamType: 'final',
+        streamId: this._streamId,
+        streamResult: this._message ? 'success' : 'error',
+        streamSequence: this._nextSequence++
+      })
+    } else if (this.isM365Copilot()) {
+      activity.entities!.push({
+        type: 'streaminfo',
+        streamType: 'streaming',
+        streamSequence: this._nextSequence++
       })
     }
 
@@ -465,6 +585,8 @@ export class StreamingResponse {
    * @private
    */
   private async sendActivity (activity: Activity): Promise<void> {
+    this.startStreamTimers()
+
     // Set activity ID to the assigned stream ID
     if (this._streamId) {
       activity.id = this._streamId
@@ -507,6 +629,9 @@ export class StreamingResponse {
       if (!this._streamId) {
         this._streamId = response?.id
       }
+      if (activity.entities?.some(entity => entity.streamType === 'informative')) {
+        this.scheduleKeepAlive()
+      }
       await new Promise((resolve) => setTimeout(resolve, this.delayInMs))
     } catch (error) {
       const { message } = error as Error
@@ -515,7 +640,16 @@ export class StreamingResponse {
       this._queue = []
 
       // MS Teams code list: https://learn.microsoft.com/en-us/microsoftteams/platform/bots/streaming-ux?tabs=jsts#error-codes
-      if (message.includes('ContentStreamNotAllowed')) {
+      const normalizedMessage = message.toLowerCase()
+      if (normalizedMessage.includes('contentstreamnotallowed') && normalizedMessage.includes(teamsStreamTimedOut.toLowerCase())) {
+        logger.warn('Client canceled due to exceeded allowed streaming time.', { originalError: message })
+        this._streamTimedOut = true
+        this._canceled = false
+        this._isStreamingChannel = false
+        this._chunkQueued = false
+        this.clearStreamTimers()
+        await this.updateActivity(this.createStreamTimedOutMessage())
+      } else if (normalizedMessage.includes('contentstreamnotallowed')) {
         logger.warn('Streaming content is not allowed by the client side.', { originalError: message })
         this._userCanceled = true
       } else if (message.includes('BadArgument') && message.toLowerCase().includes('streaming api is not enabled')) {
@@ -524,6 +658,97 @@ export class StreamingResponse {
         this._isStreamingChannel = false
       }
     }
+  }
+
+  /**
+   * Updates the existing streaming activity without allowing failures to escape the queue.
+   */
+  private async updateActivity (activity: Activity): Promise<void> {
+    try {
+      await this._context.updateActivity(activity)
+    } catch (error) {
+      logger.warn('Exception during StreamingResponse updateActivity.', { originalError: (error as Error).message })
+    }
+  }
+
+  /**
+   * Starts M365 Copilot keep-alive and maximum-duration timers.
+   */
+  private startStreamTimers (): void {
+    if (!this.isM365Copilot() || !this.isStreamingChannel || this._streamStartedAt !== undefined) {
+      return
+    }
+
+    this._streamStartedAt = Date.now()
+    this.scheduleKeepAlive()
+    this._streamTimeoutTimer = setTimeout(() => {
+      this.handleM365StreamTimeout().catch(error => {
+        logger.error('Error handling the M365 Copilot streaming timeout.', { originalError: (error as Error).message })
+      })
+    }, m365StreamingTimeoutMs)
+  }
+
+  /**
+   * Schedules an informative update before M365 Copilot's idle timeout.
+   */
+  private scheduleKeepAlive (): void {
+    if (!this.isM365Copilot() || !this.isStreamingChannel || this._ended) {
+      return
+    }
+
+    if (this._keepAliveTimer) {
+      clearTimeout(this._keepAliveTimer)
+    }
+
+    this._keepAliveTimer = setTimeout(() => {
+      this._keepAliveTimer = undefined
+      if (!this._ended && this.isStreamingChannel && this._queue.length === 0) {
+        this.queueInformativeUpdate(this._lastInformationalMessageSent.trim()
+          ? this._lastInformationalMessageSent
+          : this.streamingTakingTooLongMessage)
+      }
+    }, m365WorkingNoticeIntervalMs)
+  }
+
+  /**
+   * Finalizes an M365 Copilot stream that reached the channel duration limit.
+   */
+  private async handleM365StreamTimeout (): Promise<void> {
+    if (this._ended || !this.isStreamingChannel || !this.isM365Copilot()) {
+      return
+    }
+
+    const timedOutActivities = this._message
+      ? [this.createStreamTimedOutMessage(), this.createStreamTimedOutMessage(true)]
+      : [this.createStreamTimedOutMessage(true)]
+
+    this._streamTimeoutNotificationSent = true
+    this._isStreamingChannel = false
+    this._queue = []
+    this._chunkQueued = false
+    this.clearStreamTimers()
+
+    for (const activity of timedOutActivities) {
+      await this.sendActivity(activity)
+    }
+  }
+
+  /**
+   * Stops active channel timeout timers.
+   */
+  private clearStreamTimers (): void {
+    if (this._keepAliveTimer) {
+      clearTimeout(this._keepAliveTimer)
+      this._keepAliveTimer = undefined
+    }
+    if (this._streamTimeoutTimer) {
+      clearTimeout(this._streamTimeoutTimer)
+      this._streamTimeoutTimer = undefined
+    }
+  }
+
+  private isM365Copilot (): boolean {
+    return this._context.activity.channelId === Channels.M365Copilot
   }
 
   /**

--- a/packages/agents-hosting/src/app/streaming/streamingResponse.ts
+++ b/packages/agents-hosting/src/app/streaming/streamingResponse.ts
@@ -716,6 +716,7 @@ export class StreamingResponse {
   /**
    * Finalizes an M365 Copilot stream that reached the channel duration limit.
    */
+  private async handleM365StreamTimeout (): Promise<void> {
     if (this._ended || this._canceled || !this.isStreamingChannel || !this.isM365Copilot()) {
       return
     }

--- a/packages/agents-hosting/test/hosting/app/streamingResponse.test.ts
+++ b/packages/agents-hosting/test/hosting/app/streamingResponse.test.ts
@@ -397,6 +397,94 @@ describe('StreamingResponse', () => {
     })
   })
 
+  it('should update the streamed activity when the channel streaming timeout is reported', async () => {
+    mockContext.sendActivity.onSecondCall().rejects(
+      new Error('ContentStreamNotAllowed: Content stream finished due to exceeded streaming time.')
+    )
+
+    streamingResponse.queueInformativeUpdate('Starting...')
+    await clock.tickAsync(500)
+    streamingResponse.queueTextChunk('Completed response text.')
+    await clock.tickAsync(500)
+
+    assert.equal(streamingResponse.isStreamingChannel, false)
+    sinon.assert.calledOnce(mockContext.updateActivity)
+    const checkpoint = mockContext.updateActivity.firstCall.args[0] as Activity
+    assert.equal(checkpoint.id, 'test-stream-id')
+    assert.match(checkpoint.text!, /taking longer than expected/)
+
+    const result = await streamingResponse.endStream()
+
+    assert.equal(result, StreamingResponseResult.Success)
+    sinon.assert.calledTwice(mockContext.updateActivity)
+    const finalActivity = mockContext.updateActivity.secondCall.args[0] as Activity
+    assert.equal(finalActivity.id, 'test-stream-id')
+    assert.equal(finalActivity.text, 'Completed response text.')
+  })
+
+  it('should stop streaming after a timeout notification and send the completed response normally', async () => {
+    streamingResponse.queueInformativeUpdate('Starting...')
+    await clock.tickAsync(500)
+
+    const timeoutPromise = streamingResponse.sendStreamTimedOutNotification('Streaming timed out.')
+    await clock.tickAsync(500)
+    assert.equal(await timeoutPromise, true)
+    assert.equal(streamingResponse.isStreamingChannel, false)
+
+    streamingResponse.queueTextChunk('Completed response text.')
+    const endPromise = streamingResponse.endStream()
+    await clock.tickAsync(500)
+    assert.equal(await endPromise, StreamingResponseResult.Success)
+
+    const timeoutActivity = mockContext.sendActivity.secondCall.args[0] as Activity
+    assert.equal(timeoutActivity.text, 'Streaming timed out.')
+    assert.equal(timeoutActivity.entities?.[0].streamType, 'final')
+
+    const finalActivity = mockContext.sendActivity.thirdCall.args[0] as Activity
+    assert.equal(finalActivity.text, 'Completed response text.')
+    assert.equal(finalActivity.entities?.some(entity => entity.type === 'streaminfo'), false)
+  })
+
+  it('should send a keep-alive informative update for an idle M365 Copilot stream', async () => {
+    mockContext = createContext({ channelId: Channels.M365Copilot })
+    streamingResponse = new StreamingResponse(mockContext)
+    streamingResponse.streamingTakingTooLongMessage = 'Still working...'
+
+    streamingResponse.queueInformativeUpdate('Starting...')
+    await clock.tickAsync(36000)
+
+    sinon.assert.calledTwice(mockContext.sendActivity)
+    const keepAlive = mockContext.sendActivity.secondCall.args[0] as Activity
+    assert.equal(keepAlive.type, 'typing')
+    assert.equal(keepAlive.text, 'Starting...')
+    assert.equal(keepAlive.entities?.[0].streamType, 'informative')
+  })
+
+  it('should finalize an M365 Copilot stream at the channel timeout and fall back to non-streaming', async () => {
+    mockContext = createContext({ channelId: Channels.M365Copilot })
+    streamingResponse = new StreamingResponse(mockContext)
+    streamingResponse.streamingTakingTooLongMessage = 'Still working...'
+
+    streamingResponse.queueTextChunk('Buffered response')
+    await clock.tickAsync(108000)
+
+    assert.equal(streamingResponse.isStreamingChannel, false)
+    const timeoutFinal = mockContext.sendActivity.args
+      .map(args => args[0] as Activity)
+      .find(activity => activity.entities?.some(entity => entity.streamType === 'final'))
+    assert.ok(timeoutFinal)
+    assert.match(timeoutFinal.text!, /Still working/)
+
+    streamingResponse.queueTextChunk(' complete.')
+    const endPromise = streamingResponse.endStream()
+    await clock.tickAsync(1000)
+    assert.equal(await endPromise, StreamingResponseResult.Success)
+
+    const finalActivity = mockContext.sendActivity.lastCall.args[0] as Activity
+    assert.equal(finalActivity.text, 'Buffered response complete.')
+    assert.equal(finalActivity.entities?.some(entity => entity.type === 'streaminfo'), false)
+  })
+
   it('should send one activity for non-streaming channels', async () => {
     mockContext = createContext({ channelId: Channels.Facebook })
     streamingResponse = new StreamingResponse(mockContext)


### PR DESCRIPTION
Fixes #1220

This pull request adds robust support for streaming timeouts and keep-alive notifications to the `StreamingResponse` class, particularly for Microsoft 365 Copilot and Teams channels. It introduces timers to handle maximum streaming durations, sends user notifications when streaming is taking too long, and ensures graceful fallback when streaming is no longer allowed. The changes also include comprehensive tests covering these scenarios.

**Streaming timeout handling and notifications:**

* Added timers to enforce maximum streaming duration for M365 Copilot, sending a "taking too long" message and finalizing the stream when the limit is reached. (`packages/agents-hosting/src/app/streaming/streamingResponse.ts`, [[1]](diffhunk://#diff-0bf8103fcdb8949e7319c9d73139fdfdeef60a495036065f043843ded3c8c9b0R64-R70) [[2]](diffhunk://#diff-0bf8103fcdb8949e7319c9d73139fdfdeef60a495036065f043843ded3c8c9b0R141-R164) [[3]](diffhunk://#diff-0bf8103fcdb8949e7319c9d73139fdfdeef60a495036065f043843ded3c8c9b0R588-R589) [[4]](diffhunk://#diff-0bf8103fcdb8949e7319c9d73139fdfdeef60a495036065f043843ded3c8c9b0R663-R753)
* Implemented `sendStreamTimedOutNotification()` to allow manual interruption of a stream with a user notification and proper state cleanup. (`packages/agents-hosting/src/app/streaming/streamingResponse.ts`, [packages/agents-hosting/src/app/streaming/streamingResponse.tsR405-R424](diffhunk://#diff-0bf8103fcdb8949e7319c9d73139fdfdeef60a495036065f043843ded3c8c9b0R405-R424))
* Enhanced error handling for Teams' streaming timeout errors, updating the activity and disabling streaming as appropriate. (`packages/agents-hosting/src/app/streaming/streamingResponse.ts`, [packages/agents-hosting/src/app/streaming/streamingResponse.tsL518-R652](diffhunk://#diff-0bf8103fcdb8949e7319c9d73139fdfdeef60a495036065f043843ded3c8c9b0L518-R652))

**Keep-alive and informative updates:**

* Introduced periodic keep-alive "informative" updates for idle M365 Copilot streams to prevent premature termination due to inactivity. (`packages/agents-hosting/src/app/streaming/streamingResponse.ts`, [[1]](diffhunk://#diff-0bf8103fcdb8949e7319c9d73139fdfdeef60a495036065f043843ded3c8c9b0R588-R589) [[2]](diffhunk://#diff-0bf8103fcdb8949e7319c9d73139fdfdeef60a495036065f043843ded3c8c9b0R663-R753)

**Testing:**

* Added comprehensive tests for timeout handling, keep-alive updates, and fallback behaviors in `streamingResponse.test.ts`. (`packages/agents-hosting/test/hosting/app/streamingResponse.test.ts`, [packages/agents-hosting/test/hosting/app/streamingResponse.test.tsR400-R487](diffhunk://#diff-6ca3430e062744746a1fda362423c710d7e4b649a6b3ccac88fa14002fe4de75R400-R487))

**API updates:**

* Updated the public API in `agents-hosting.api.md` to include the new timeout notification method and properties for customizing timeout messages. (`compat/baseline/agents-hosting.api.md`, [[1]](diffhunk://#diff-eeda38696bc38a513b5b5545af7c7340abd13c44be2cd73c0881902ac64e85a1R1374) [[2]](diffhunk://#diff-eeda38696bc38a513b5b5545af7c7340abd13c44be2cd73c0881902ac64e85a1R1384-R1385)

These changes ensure that long-running streams are handled gracefully, users receive timely feedback, and the application remains robust across supported channels.
