### PR TITLE
[#1191] Create workflow to detect differences between Teams API and Agents Teams Extension

### DIFF
--- a/.github/workflows/scheduled-teams-api-drift.yml
+++ b/.github/workflows/scheduled-teams-api-drift.yml
@@ -1,0 +1,239 @@
+name: Scheduled Teams API Drift Detector
+
+# Periodically compares the declared teams.api baseline with the latest stable npm release.
+# When the public API changes, it publishes deterministic artifacts and upserts an advisory issue.
+on:
+  schedule:
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  copilot-requests: write
+  issues: write
+
+concurrency:
+  group: scheduled-teams-api-drift
+  cancel-in-progress: false
+
+jobs:
+  detect-and-report:
+    name: Detect and report teams.api drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+
+      - id: resolve-baseline-version
+        name: Resolve declared baseline version
+        run: |
+          baseline_range=$(node -p "require('./packages/agents-hosting-extensions-msteams/package.json').dependencies['@microsoft/teams.api']")
+          baseline_version=$(node -e "const match = process.argv[1].match(/[0-9]+\\.[0-9]+\\.[0-9]+/); if (!match) process.exit(1); console.log(match[0])" "$baseline_range")
+          echo "version=$baseline_version" >> "$GITHUB_OUTPUT"
+
+      # Continue so reports and artifacts remain available if a compatibility check fails.
+      - id: build
+        name: Build
+        run: npm run build
+        continue-on-error: true
+      - id: verify-usage-manifest
+        name: Verify dependency usage manifest
+        if: always()
+        run: test -f packages/agents-hosting-extensions-msteams/teams-api-usage-manifest.json
+        continue-on-error: true
+      - id: compare-upstream-api-models
+        name: Compare baseline with latest stable teams.api
+        if: always() && steps.build.outcome == 'success'
+        run: >-
+          npm run compare:teams-api --
+          --from "${{ steps.resolve-baseline-version.outputs.version }}"
+          --output artifacts/teams-api-drift
+        continue-on-error: true
+      - id: comparison-result
+        name: Read comparison result
+        if: always() && steps.compare-upstream-api-models.outcome == 'success'
+        run: |
+          node -e "const fs = require('fs'); const result = JSON.parse(fs.readFileSync('artifacts/teams-api-drift/raw-api-diff.json', 'utf8')); console.log('changed=' + String(result.changed)); console.log('candidate_version=' + result.toVersion)" >> "$GITHUB_OUTPUT"
+      - id: run-compile-time-contracts-tests
+        name: Run compile-time contracts tests
+        if: always() && steps.build.outcome == 'success'
+        run: npm run test:teams-api-contracts
+        continue-on-error: true
+      - id: run-runtime-boundaries-tests
+        name: Run Teams API runtime boundaries tests
+        if: always() && steps.build.outcome == 'success'
+        run: node --test --import tsx packages/agents-hosting-extensions-msteams/test/boundaries/teamsApiClientBehavior.test.ts
+        continue-on-error: true
+      - id: classify-usage-impact
+        name: Classify direct compatibility impact
+        if: always() && steps.compare-upstream-api-models.outcome == 'success'
+        run: npm run detect:teams-api-drifts -- --comparison artifacts/teams-api-drift/raw-api-diff.json --output artifacts/teams-api-drift --fail-on-drift
+        continue-on-error: true
+      - id: write-verification-summary
+        name: Write verification summary
+        if: always()
+        run: >-
+          npm run write:teams-api-test-summary --
+          --build "${{ steps.build.outcome }}"
+          --usage-collection "${{ steps.verify-usage-manifest.outcome }}"
+          --api-extraction "${{ steps.compare-upstream-api-models.outcome }}"
+          --api-comparison "${{ steps.compare-upstream-api-models.outcome }}"
+          --contract-tests "${{ steps.run-compile-time-contracts-tests.outcome }}"
+          --boundary-tests "${{ steps.run-runtime-boundaries-tests.outcome }}"
+          --output artifacts/teams-api-drift
+        continue-on-error: true
+      - id: render-deterministic-report
+        name: Render deterministic report
+        if: always() && steps.classify-usage-impact.outcome != 'skipped' && steps.write-verification-summary.outcome == 'success'
+        run: npm run render:teams-api-drift-report -- --findings artifacts/teams-api-drift/findings.json --test-summary artifacts/teams-api-drift/test-summary.json --output artifacts/teams-api-drift
+        continue-on-error: true
+
+      # The AI runner receives bounded artifacts and has no repository tools available.
+      - id: prepare-agent-context
+        name: Prepare bounded AI agent context
+        if: always() && steps.comparison-result.outputs.changed == 'true' && steps.render-deterministic-report.outcome == 'success'
+        run: >-
+          npm run prepare:teams-api-agent-report --
+          --findings artifacts/teams-api-drift/findings.json
+          --usage-manifest packages/agents-hosting-extensions-msteams/teams-api-usage-manifest.json
+          --capabilities packages/agents-hosting-extensions-msteams/config/teams-capabilities.yaml
+          --deterministic-report artifacts/teams-api-drift/deterministic-report.md
+          --test-summary artifacts/teams-api-drift/test-summary.json
+          --output artifacts/teams-api-drift
+        continue-on-error: true
+      - id: install-copilot-cli
+        name: Install GitHub Copilot CLI
+        if: always() && steps.prepare-agent-context.outcome == 'success'
+        run: npm install --global @github/copilot
+        continue-on-error: true
+      - id: generate-advisory-report
+        name: Generate advisory AI report
+        if: always() && steps.install-copilot-cli.outcome == 'success'
+        env:
+          # Authenticates GitHub Copilot CLI with this workflow's copilot-requests permission.
+          GITHUB_TOKEN: ${{ github.token }}
+          PROMPT_FILE: scripts/teams-api-drift/teams-api-agent-report-prompt.md
+          CONTEXT_FILE: artifacts/teams-api-drift/agent-context.json
+          REPORT_FILE: artifacts/teams-api-drift/agent-report.md
+        run: |
+          agent_prompt=$(cat "$PROMPT_FILE")
+          agent_context=$(cat "$CONTEXT_FILE")
+          copilot \
+            -s \
+            -p "$agent_prompt
+
+          ## Runtime context
+
+          \`\`\`json
+          $agent_context
+          \`\`\`" \
+            --deny-tool='shell,write,read,url,memory,github' \
+            --no-ask-user \
+            > "$REPORT_FILE"
+          test -s "$REPORT_FILE"
+        continue-on-error: true
+      - id: validate-advisory-report
+        name: Validate advisory AI report
+        if: always() && steps.generate-advisory-report.outcome == 'success'
+        run: >-
+          npm run validate:teams-api-agent-report --
+          --findings artifacts/teams-api-drift/findings.json
+          --report artifacts/teams-api-drift/agent-report.md
+          --output artifacts/teams-api-drift
+        continue-on-error: true
+
+      # Upload evidence before the policy gate or issue update can fail the run.
+      - name: Upload scheduled drift artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scheduled-teams-api-drift-${{ github.run_id }}
+          path: artifacts/teams-api-drift
+          if-no-files-found: warn
+          retention-days: 30
+      - name: Create or update drift issue
+        if: always() && steps.comparison-result.outputs.changed == 'true' && steps.validate-advisory-report.outcome == 'success'
+        uses: actions/github-script@v7
+        env:
+          BASELINE_VERSION: ${{ steps.resolve-baseline-version.outputs.version }}
+          CANDIDATE_VERSION: ${{ steps.comparison-result.outputs.candidate_version }}
+          ARTIFACT_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const fs = require('fs')
+            const marker = `<!-- scheduled-teams-api-drift:${process.env.CANDIDATE_VERSION} -->`
+            const title = `teams.api drift detected: ${process.env.BASELINE_VERSION} → ${process.env.CANDIDATE_VERSION}`
+            const advisoryReport = fs.readFileSync('artifacts/teams-api-drift/agent-report.md', 'utf8').trim()
+            const body = [
+              marker,
+              `Scheduled comparison of \`@microsoft/teams.api\` **${process.env.BASELINE_VERSION}** to **${process.env.CANDIDATE_VERSION}** found API differences.`,
+              '',
+              advisoryReport,
+              '',
+              `Deterministic artifacts: ${process.env.ARTIFACT_URL}`
+            ].join('\n')
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            })
+            const existing = issues.find(issue => !issue.pull_request && issue.body?.includes(marker))
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                title,
+                body
+              })
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body
+              })
+            }
+      # Make compatibility failures visible after artifacts and any valid advisory issue are published.
+      - name: Enforce scheduled drift policy
+        if: always()
+        env:
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          USAGE_MANIFEST_OUTCOME: ${{ steps.verify-usage-manifest.outcome }}
+          UPSTREAM_COMPARISON_OUTCOME: ${{ steps.compare-upstream-api-models.outcome }}
+          COMPILE_TIME_CONTRACTS_OUTCOME: ${{ steps.run-compile-time-contracts-tests.outcome }}
+          RUNTIME_BOUNDARIES_OUTCOME: ${{ steps.run-runtime-boundaries-tests.outcome }}
+          IMPACT_CLASSIFICATION_OUTCOME: ${{ steps.classify-usage-impact.outcome }}
+          VERIFICATION_SUMMARY_OUTCOME: ${{ steps.write-verification-summary.outcome }}
+          DETERMINISTIC_REPORT_OUTCOME: ${{ steps.render-deterministic-report.outcome }}
+          DRIFT_CHANGED: ${{ steps.comparison-result.outputs.changed }}
+          AGENT_CONTEXT_OUTCOME: ${{ steps.prepare-agent-context.outcome }}
+          COPILOT_INSTALL_OUTCOME: ${{ steps.install-copilot-cli.outcome }}
+          AGENT_REPORT_OUTCOME: ${{ steps.generate-advisory-report.outcome }}
+          AGENT_VALIDATION_OUTCOME: ${{ steps.validate-advisory-report.outcome }}
+        run: |
+          for outcome in "$BUILD_OUTCOME" "$USAGE_MANIFEST_OUTCOME" "$UPSTREAM_COMPARISON_OUTCOME" "$COMPILE_TIME_CONTRACTS_OUTCOME" "$RUNTIME_BOUNDARIES_OUTCOME" "$IMPACT_CLASSIFICATION_OUTCOME" "$VERIFICATION_SUMMARY_OUTCOME" "$DETERMINISTIC_REPORT_OUTCOME"; do
+            if [ "$outcome" != success ]; then
+              echo "Blocking scheduled teams.api drift check outcome: $outcome"
+              exit 1
+            fi
+          done
+
+          if [ "$DRIFT_CHANGED" = true ]; then
+            for outcome in "$AGENT_CONTEXT_OUTCOME" "$COPILOT_INSTALL_OUTCOME" "$AGENT_REPORT_OUTCOME" "$AGENT_VALIDATION_OUTCOME"; do
+              if [ "$outcome" != success ]; then
+                echo "Blocking scheduled teams.api AI report outcome: $outcome"
+                exit 1
+              fi
+            done
+          fi

--- a/.github/workflows/teams-api-drift-prs.yml
+++ b/.github/workflows/teams-api-drift-prs.yml
@@ -36,7 +36,7 @@ jobs:
       candidate_version: ${{ steps.resolve-versions.outputs.candidate_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -88,11 +88,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm
@@ -212,12 +212,12 @@ jobs:
       # Upload all evidence before the final policy turns collected failures into a failed workflow.
       - name: Upload compatibility artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: teams-api-drift-${{ github.run_id }}
           path: artifacts/teams-api-drift
           if-no-files-found: warn
-          retention-days: 14
+          retention-days: 21
       # Upsert one marker-based summary comment only for trusted pull requests.
       - name: Publish pull-request comment
         if: always() && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) && steps.render-deterministic-report.outcome == 'success'

--- a/.github/workflows/teams-api-drift-prs.yml
+++ b/.github/workflows/teams-api-drift-prs.yml
@@ -36,7 +36,7 @@ jobs:
       candidate_version: ${{ steps.resolve-versions.outputs.candidate_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -88,11 +88,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm
@@ -212,16 +212,16 @@ jobs:
       # Upload all evidence before the final policy turns collected failures into a failed workflow.
       - name: Upload compatibility artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: teams-api-drift-${{ github.run_id }}
           path: artifacts/teams-api-drift
           if-no-files-found: warn
-          retention-days: 14
+          retention-days: 21
       # Upsert one marker-based summary comment only for trusted pull requests.
       - name: Publish pull-request comment
         if: always() && github.event_name == 'pull_request' && steps.render-deterministic-report.outcome == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           ARTIFACT_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:

--- a/.github/workflows/teams-api-drift-scheduled.yml
+++ b/.github/workflows/teams-api-drift-scheduled.yml
@@ -4,6 +4,7 @@ name: Scheduled Teams API Drift Detector
 # When the public API changes, it publishes deterministic artifacts and upserts an advisory issue.
 on:
   schedule:
+    # Runs at 08:00 UTC every Monday (~1am PST)
     - cron: '0 8 * * 1'
   workflow_dispatch:
 
@@ -22,11 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm
@@ -154,15 +155,15 @@ jobs:
       # Upload evidence before the policy gate or issue update can fail the run.
       - name: Upload scheduled drift artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: scheduled-teams-api-drift-${{ github.run_id }}
           path: artifacts/teams-api-drift
           if-no-files-found: warn
-          retention-days: 30
+          retention-days: 21
       - name: Create or update drift issue
         if: always() && steps.comparison-result.outputs.changed == 'true' && steps.validate-advisory-report.outcome == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           BASELINE_VERSION: ${{ steps.resolve-baseline-version.outputs.version }}
           CANDIDATE_VERSION: ${{ steps.comparison-result.outputs.candidate_version }}
@@ -170,14 +171,16 @@ jobs:
         with:
           script: |
             const fs = require('fs')
-            const marker = `<!-- scheduled-teams-api-drift:${process.env.CANDIDATE_VERSION} -->`
+            const marker = '<!-- scheduled-teams-api-drift -->'
             const title = `teams.api drift detected: ${process.env.BASELINE_VERSION} → ${process.env.CANDIDATE_VERSION}`
             const advisoryReport = fs.readFileSync('artifacts/teams-api-drift/agent-report.md', 'utf8').trim()
             const body = [
-              marker,
-              `Scheduled comparison of \`@microsoft/teams.api\` **${process.env.BASELINE_VERSION}** to **${process.env.CANDIDATE_VERSION}** found API differences.`,
-              '',
-              advisoryReport,
+               marker,
+               `Scheduled comparison of \`@microsoft/teams.api\` **${process.env.BASELINE_VERSION}** to **${process.env.CANDIDATE_VERSION}** found API differences.`,
+               '',
+               'Maintainers should review this advisory report and its deterministic evidence. Some findings may require follow-up before adopting the candidate version.',
+               '',
+               advisoryReport,
               '',
               `Deterministic artifacts: ${process.env.ARTIFACT_URL}`
             ].join('\n')

--- a/packages/agents-hosting-extensions-msteams/test/drift/teamsApiAgentReportValidation.test.ts
+++ b/packages/agents-hosting-extensions-msteams/test/drift/teamsApiAgentReportValidation.test.ts
@@ -55,6 +55,14 @@ describe('teams.api agent report validation', () => {
     assert.ok(validation.errors.includes('Summary section must start with: "This is an advisory report; it does not make or authorize implementation decisions.".'))
   })
 
+  it('should allow a summary to continue after the required advisory sentence', () => {
+    const validation = validateAgentReport(report({
+      Summary: 'This is an advisory report; it does not make or authorize implementation decisions. This upgrade has no mandatory adaptations.'
+    }), findings())
+
+    assert.deepEqual(validation.errors, [])
+  })
+
   it('should require blocking and required finding IDs', () => {
     const validation = validateAgentReport(report(), findings(
       { id: 'TSAPI-0001', classification: 'blocking' },

--- a/scripts/teams-api-drift/teams-api-agent-report-prompt.md
+++ b/scripts/teams-api-drift/teams-api-agent-report-prompt.md
@@ -33,6 +33,12 @@ Use each of these level-two headings exactly once and in this order:
 
 ## Validation checklist
 
+Formatting is validated mechanically:
+
+- Write the title and every listed heading on its own line exactly as shown.
+- Put a blank line after each heading and start its content on the following line.
+- Do not append narrative text to a heading or combine multiple sections into one line.
+
 Follow these rules:
 
 - Treat `authoritativeArtifacts.findings` as the source of truth for finding

--- a/scripts/teams-api-drift/validate-teams-api-agent-report.ts
+++ b/scripts/teams-api-drift/validate-teams-api-agent-report.ts
@@ -111,10 +111,10 @@ export function validateAgentReport (report: string, findings: FindingsResult): 
     previousSectionIndex = index
   }
   const requiredSummarySentence = 'This is an advisory report; it does not make or authorize implementation decisions.'
-  const summaryMatch = normalizedReport.match(/^## Summary\s*$(?:\n)([\s\S]*?)(?=\n## |\s*$)/m)
+  const summaryMatch = normalizedReport.match(/^## Summary[ \t]*\n([\s\S]*)/m)
   const summaryContent = summaryMatch?.[1] ?? ''
   const firstSummaryLine = summaryContent.split('\n').map(line => line.trim()).find(line => line.length > 0)
-  if (firstSummaryLine !== requiredSummarySentence) {
+  if (!firstSummaryLine?.startsWith(requiredSummarySentence)) {
     errors.push(`Summary section must start with: "${requiredSummarySentence}".`)
   }
 

--- a/scripts/teams-api-drift/validate-teams-api-agent-report.ts
+++ b/scripts/teams-api-drift/validate-teams-api-agent-report.ts
@@ -102,10 +102,10 @@ export function validateAgentReport (report: string, findings: FindingsResult): 
     if (!new RegExp(`^## ${section}$`, 'm').test(normalizedReport)) errors.push(`Missing required section: ${section}.`)
   }
   const requiredSummarySentence = 'This is an advisory report; it does not make or authorize implementation decisions.'
-  const summaryMatch = normalizedReport.match(/^## Summary\s*$(?:\n)([\s\S]*?)(?=\n## |\s*$)/m)
+  const summaryMatch = normalizedReport.match(/^## Summary[ \t]*\n([\s\S]*)/m)
   const summaryContent = summaryMatch?.[1] ?? ''
   const firstSummaryLine = summaryContent.split('\n').map(line => line.trim()).find(line => line.length > 0)
-  if (firstSummaryLine !== requiredSummarySentence) {
+  if (!firstSummaryLine?.startsWith(requiredSummarySentence)) {
     errors.push(`Summary section must start with: "${requiredSummarySentence}".`)
   }
 


### PR DESCRIPTION
Fixes #1191

## Description

This pull request introduces a scheduled workflow for detecting drift in the Teams API and updates the existing pull request drift detection workflow to use newer GitHub Actions versions and improved retention policies. It also enhances the validation logic for advisory reports, allowing the summary section to include additional text after the required advisory statement, and clarifies formatting requirements in the agent report prompt.

### Detailed Changes
**Scheduled Teams API Drift Detection:**

* Added a new workflow (`.github/workflows/teams-api-drift-scheduled.yml`) that periodically compares the declared Teams API baseline with the latest stable release, publishes artifacts, and creates or updates advisory issues when drift is detected.

**Workflow Improvements and Dependency Updates:**

* Updated the pull request drift detection workflow (`.github/workflows/teams-api-drift.yml` → `teams-api-drift-prs.yml`) to use the latest major versions of GitHub Actions (`actions/checkout@v5`, `actions/setup-node@v5`, `actions/upload-artifact@v6`, `actions/github-script@v8`) and increased artifact retention from 14 to 21 days. [[1]](diffhunk://#diff-127c9e604823010478571ba97f6499a8d7e2be791d7c7068f4faba2125c2fcbfL39-R39) [[2]](diffhunk://#diff-127c9e604823010478571ba97f6499a8d7e2be791d7c7068f4faba2125c2fcbfL91-R95) [[3]](diffhunk://#diff-127c9e604823010478571ba97f6499a8d7e2be791d7c7068f4faba2125c2fcbfL215-R224)

**Report Validation and Prompt Improvements:**

* Enhanced the agent report validation logic (`scripts/teams-api-drift/validate-teams-api-agent-report.ts`) to allow the summary section to continue after the required advisory sentence, as long as it starts with the exact statement.
* Added a test to ensure summaries are permitted to include additional content after the required advisory sentence (`teamsApiAgentReportValidation.test.ts`).
* Clarified formatting requirements in the agent report prompt, specifying that headings must be on their own lines and not combined with content (`teams-api-agent-report-prompt.md`).

## Testing
These images show the workflow running and the generated issue with reported drifts.

<img width="1995" height="1225" alt="image" src="https://github.com/user-attachments/assets/64a633a1-fcb7-4d21-b085-1e998c885657" />