### PR TITLE
feat: add JWT authorization middleware by default for agent-to-agent …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 dist/
 *.env
+.env.*
+!.env.*.TEMPLATE
 *.key
 *.pem
 test-report.xml

--- a/compat/baseline/agents-hosting.api.md
+++ b/compat/baseline/agents-hosting.api.md
@@ -547,6 +547,7 @@ export class CloudAdapter extends BaseAdapter {
     protected _agentName?: string;
     // (undocumented)
     protected readonly authConfig: AuthConfiguration;
+    authorizeRequest(req: Request_2, res: WebResponse, next: NextFunction): Promise<void>;
     connectionManager: Connections;
     continueConversation(botAppIdOrIdentity: string | JwtPayload, reference: ConversationReference, logic: (revocableContext: TurnContext) => Promise<void>, isResponse?: Boolean): Promise<void>;
     protected createConnectorClient(serviceUrl: string, scope: string, identity: JwtPayload, headers?: HeaderPropagationCollection): Promise<ConnectorClient>;
@@ -562,6 +563,7 @@ export class CloudAdapter extends BaseAdapter {
     getAttachment(context: TurnContext, attachmentId: string, viewId: string): Promise<NodeJS.ReadableStream>;
     // @deprecated (undocumented)
     getAttachmentInfo(context: TurnContext, attachmentId: string): Promise<AttachmentInfo>;
+    getClientId(): string | undefined;
     process(request: Request_2, res: WebResponse, logic: (context: TurnContext) => Promise<void>, headerPropagation?: HeaderPropagationDefinition): Promise<void>;
     protected processTurnResults(context: TurnContext): InvokeResponse | undefined;
     protected resolveIfConnectorClientIsNeeded(activity: Activity): boolean;
@@ -719,6 +721,7 @@ export interface ConversationClaims {
 // @public
 export interface ConversationData {
     conversationReference: ConversationReference;
+    expectedAgentClientId?: string;
     nameRequested: boolean;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2455,6 +2455,10 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/a2a-agent": {
+      "resolved": "test-agents/a2a-agent",
+      "link": true
+    },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
@@ -8430,6 +8434,15 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "test-agents/a2a-agent": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
+        "@microsoft/agents-hosting-express": "file:../../packages/agents-hosting-express",
+        "express": "5.2.1"
       }
     },
     "test-agents/agentic-ai": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8442,7 +8442,8 @@
       "dependencies": {
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/agents-hosting-express": "file:../../packages/agents-hosting-express",
-        "express": "5.2.1"
+        "express": "5.2.1",
+        "express-rate-limit": "8.5.2"
       }
     },
     "test-agents/agentic-ai": {

--- a/packages/agents-hosting-fastify/README.md
+++ b/packages/agents-hosting-fastify/README.md
@@ -8,9 +8,9 @@ Fastify hosting integration for the Microsoft 365 Agents SDK. Provides three lev
 - **`agentsHostingFastifyPlugin`** (default export) — A standard (encapsulated) Fastify async plugin you can register on an existing Fastify instance, with optional `prefix`.
 - **`createAgentRequestHandler`** — A handler `(request, reply) => Promise<void>` for users who want to register the route themselves.
 
-Fastify parses JSON request bodies automatically, so no equivalent of `express.json()` is required. JWT authorization and rate limiting are applied per-route to the messages endpoint only, so any custom routes you add remain unauthenticated and un-throttled.
+Fastify parses JSON request bodies automatically, so no equivalent of `express.json()` is required. JWT authorization and rate limiting are applied per-route to the messages endpoint only, so custom routes you add remain unauthenticated and un-throttled. The agent-response route registered by `configureResponseController` applies JWT authorization internally.
 
-The package also re-exports `createCloudAdapter` (and `CloudAdapterResult`) from `@microsoft/agents-hosting`, plus `configureResponseController` for wiring the agent-to-agent response endpoint on a Fastify instance.
+The package also re-exports `createCloudAdapter` (and `CloudAdapterResult`) from `@microsoft/agents-hosting`, plus `configureResponseController` for wiring the authenticated agent-to-agent response endpoint on a Fastify instance. Authentication runs once through the supplied `CloudAdapter`, including support for any configured host connection; the stored delegated-agent identity then authorizes the specific conversation. Separate JWT middleware on the same route is redundant but compatible. Missing, malformed, or pre-upgrade delegated state fails closed, and pre-upgrade conversations must be restarted.
 
 ## Usage
 

--- a/packages/agents-hosting-fastify/src/configureResponseController.ts
+++ b/packages/agents-hosting-fastify/src/configureResponseController.ts
@@ -20,7 +20,8 @@ import { adaptReply } from './replyAdapter'
  * @remarks
  * Registers `POST /api/agentresponse/v3/conversations/:conversationId/activities/:activityId`
  * using the framework-agnostic handler from `@microsoft/agents-hosting`. Mirrors the
- * Express `configureResponseController` API for parity.
+ * Express `configureResponseController` API for parity. The handler authenticates
+ * callers and verifies that they own the delegated conversation before processing.
  *
  * @param fastify - The Fastify instance to register the route on.
  * @param adapter - The CloudAdapter for processing activities.

--- a/packages/agents-hosting-fastify/test/configureResponseController.test.ts
+++ b/packages/agents-hosting-fastify/test/configureResponseController.test.ts
@@ -1,49 +1,139 @@
 /**
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
- *
- * Smoke test for the Fastify configureResponseController wrapper. Verifies the
- * canonical route is registered and that path parameters are forwarded to the
- * framework-agnostic createAgentResponseHandler from core.
  */
 
-import { describe, it, before, after } from 'node:test'
+import { afterEach, describe, it } from 'node:test'
 import assert from 'node:assert'
+import sinon from 'sinon'
 import Fastify, { type FastifyInstance } from 'fastify'
-import { ActivityHandler, CloudAdapter, ConversationState, MemoryStorage } from '@microsoft/agents-hosting'
+import {
+  ActivityHandler,
+  AuthConfiguration,
+  CloudAdapter,
+  ConversationState,
+  MemoryStorage,
+  TurnContext
+} from '@microsoft/agents-hosting'
 import { configureResponseController } from '../src/configureResponseController'
 
+const makeAuthConfig = (): AuthConfiguration => {
+  const connection = {
+    clientId: 'host-client-id',
+    tenantId: 'tenant-id',
+    issuers: ['https://api.botframework.com']
+  }
+  return {
+    ...connection,
+    connections: new Map([['serviceConnection', connection]]),
+    connectionsMap: [{ connection: 'serviceConnection', serviceUrl: '*' }]
+  }
+}
+
+const seedConversation = async (storage: MemoryStorage) => {
+  await storage.write({
+    'test/conversations/c1': {
+      c1: {
+        conversationReference: {
+          activityId: 'root-activity',
+          user: { id: 'user' },
+          bot: { id: 'host' },
+          conversation: { id: 'root-conversation' },
+          channelId: 'test',
+          serviceUrl: 'https://example.test'
+        },
+        nameRequested: false,
+        expectedAgentClientId: 'delegated-agent-client-id'
+      }
+    }
+  })
+}
+
+const createServer = async (
+  callerClientId?: string
+): Promise<{ fastify: FastifyInstance, adapter: CloudAdapter, storage: MemoryStorage, agent: ActivityHandler }> => {
+  const fastify = Fastify()
+  const adapter = new CloudAdapter(makeAuthConfig())
+  const agent = new ActivityHandler()
+  const storage = new MemoryStorage()
+  await seedConversation(storage)
+  sinon.stub(adapter, 'authorizeRequest').callsFake(async (req, res, next) => {
+    if (!callerClientId) {
+      res.status(401).send({ 'jwt-auth-error': 'authorization header not found' })
+      return
+    }
+    req.user = { aud: 'host-client-id', azp: callerClientId }
+    next()
+  })
+  configureResponseController(fastify, adapter, agent, new ConversationState(storage))
+  await fastify.ready()
+  return { fastify, adapter, storage, agent }
+}
+
 describe('configureResponseController (Fastify)', () => {
-  let fastify: FastifyInstance
+  let fastify: FastifyInstance | undefined
 
-  before(async () => {
-    fastify = Fastify()
-    const adapter = new CloudAdapter({ clientId: 'test', tenantId: 't', issuers: [], connections: new Map() })
-    const conversationState = new ConversationState(new MemoryStorage())
-    configureResponseController(fastify, adapter, new ActivityHandler(), conversationState)
-    await fastify.ready()
+  afterEach(async () => {
+    sinon.restore()
+    if (fastify) {
+      await fastify.close()
+      fastify = undefined
+    }
   })
 
-  after(async () => {
-    if (fastify) await fastify.close()
+  it('registers the canonical response route', async () => {
+    ;({ fastify } = await createServer())
+    assert.match(fastify.printRoutes({ commonPrefix: false }), /agentresponse/)
   })
 
-  it('registers POST /api/agentresponse/v3/conversations/:conversationId/activities/:activityId', async () => {
-    const routes = fastify.printRoutes({ commonPrefix: false })
-    assert.ok(/agentresponse/.test(routes), 'route tree should include /agentresponse/...')
-  })
+  it('returns 401 when adapter authentication rejects the request', async () => {
+    ;({ fastify } = await createServer())
 
-  it('returns 404 for unrelated paths and accepts POST on the response route', async () => {
-    const notFound = await fastify.inject({ method: 'GET', url: '/nope' })
-    assert.strictEqual(notFound.statusCode, 404)
-    // We intentionally don't drive a full conversation here — that requires real
-    // adapter/state plumbing; the goal is to prove the route is reachable.
-    const accepted = await fastify.inject({
+    const response = await fastify.inject({
       method: 'POST',
       url: '/api/agentresponse/v3/conversations/c1/activities/a1',
-      payload: { type: 'message', text: 'x' }
+      payload: { type: 'message', channelId: 'test', conversation: { id: 'c1' } }
     })
-    // The handler will fail downstream (no real conversation reference), but routing succeeded.
-    assert.notStrictEqual(accepted.statusCode, 404, 'route should match and not 404')
+
+    assert.strictEqual(response.statusCode, 401, response.body)
+  })
+
+  it('returns 403 when the authenticated caller does not own the conversation', async () => {
+    ;({ fastify } = await createServer('different-agent-client-id'))
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/api/agentresponse/v3/conversations/c1/activities/a1',
+      payload: { type: 'message', channelId: 'test', conversation: { id: 'c1' } }
+    })
+
+    assert.strictEqual(response.statusCode, 403, response.body)
+  })
+
+  it('processes an authorized EndOfConversation response and removes delegated state', async () => {
+    let adapter: CloudAdapter
+    let storage: MemoryStorage
+    let agent: ActivityHandler
+    ;({ fastify, adapter, storage, agent } = await createServer('delegated-agent-client-id'))
+    sinon.stub(agent, 'run').resolves()
+    sinon.stub(adapter, 'continueConversation').callsFake(async (...args: any[]) => {
+      const callback = args[2]
+      const context = { activity: {} } as TurnContext
+      await callback(context)
+    })
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/api/agentresponse/v3/conversations/c1/activities/a1',
+      payload: {
+        type: 'endOfConversation',
+        channelId: 'test',
+        conversation: { id: 'c1' }
+      }
+    })
+
+    assert.strictEqual(response.statusCode, 200, response.body)
+    assert.strictEqual(response.headers['content-type'], 'text/plain; charset=utf-8')
+    assert.deepStrictEqual(await storage.read(['test/conversations/c1']), {})
   })
 })

--- a/packages/agents-hosting/README.md
+++ b/packages/agents-hosting/README.md
@@ -28,6 +28,15 @@ exposes framework-agnostic primitives that the
 Most consumers should keep using `startServer`/`createAgentRequestHandler` from the
 Express or Fastify packages; reach for these APIs when adapting another framework.
 
+The agent-response handler authenticates requests once through the supplied
+`CloudAdapter`. That boundary validates the token for any configured host connection;
+the handler then verifies that the caller application matches the delegated agent
+recorded for that conversation. Existing route-level `authorizeJWT` middleware is
+redundant but remains compatible. Anonymous callbacks are supported only outside
+production and emit a registration warning because peer ownership cannot be verified.
+Missing, malformed, or pre-upgrade delegated state fails closed. Pre-upgrade
+conversations must be restarted.
+
 ## Example Usage based on the AgentApplication object
 
 ```ts

--- a/packages/agents-hosting/src/agent-client/agentClient.ts
+++ b/packages/agents-hosting/src/agent-client/agentClient.ts
@@ -40,6 +40,10 @@ export interface ConversationData {
    * Reference to the conversation for maintaining context across interactions
    */
   conversationReference: ConversationReference;
+  /**
+   * Client ID of the delegated agent allowed to send responses for this conversation.
+   */
+  expectedAgentClientId?: string;
 }
 
 /**
@@ -91,19 +95,24 @@ export class AgentClient {
       }
       activityCopy.conversation!.id = randomUUID()
 
+      const delegatedContext = new TurnContext(context.adapter, activityCopy, context.identity)
+      const delegatedStateKey = { channelId: activityCopy.channelId!, conversationId: activityCopy.conversation!.id }
       const conversationDataAccessor = conversationState.createProperty<ConversationData>(activityCopy.conversation!.id)
-      const convRef = await conversationDataAccessor.set(context,
-        { conversationReference: activity.getConversationReference(), nameRequested: false },
-        { channelId: activityCopy.channelId!, conversationId: activityCopy.conversation!.id }
+      await conversationDataAccessor.set(delegatedContext,
+        {
+          conversationReference: activity.getConversationReference(),
+          nameRequested: false,
+          expectedAgentClientId: this.agentClientConfig.clientId
+        },
+        delegatedStateKey
       )
 
-      const stateChanges = JSON.stringify(convRef)
-      logger.debug('stateChanges: ', stateChanges)
+      logger.debug('stored delegated conversation state')
 
       const authProvider = new MsalTokenProvider(authConfig)
       const token = await authProvider.getAccessToken(this.agentClientConfig.clientId)
 
-      logger.debug('agent request: ', activityCopy)
+      logger.debug('sending activity to delegated agent')
 
       let authHeader = '' // Allow anonymous auth.
 
@@ -111,21 +120,27 @@ export class AgentClient {
         authHeader = `Bearer ${token}`
       }
 
-      await conversationState.saveChanges(context, false, { channelId: activityCopy.channelId!, conversationId: activityCopy.conversation!.id })
-      const response = await fetch(this.agentClientConfig.endPoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: authHeader,
-          'x-ms-conversation-id': activityCopy.conversation!.id
-        },
-        body: JSON.stringify(activityCopy)
-      })
+      await conversationState.saveChanges(delegatedContext, false, delegatedStateKey)
+      let response: Response
+      try {
+        response = await fetch(this.agentClientConfig.endPoint, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: authHeader,
+            'x-ms-conversation-id': activityCopy.conversation!.id
+          },
+          body: JSON.stringify(activityCopy)
+        })
+      } catch (error) {
+        await conversationState.delete(delegatedContext, delegatedStateKey)
+        throw error
+      }
 
       record({ httpStatusCode: response.status.toString() })
 
       if (!response.ok) {
-        await conversationDataAccessor.delete(context, { channelId: activityCopy.channelId!, conversationId: activityCopy.conversation!.id })
+        await conversationState.delete(delegatedContext, delegatedStateKey)
         throw ExceptionHelper.generateException(Error, Errors.FailedToPostActivityToAgent, undefined, { statusText: response.statusText })
       }
       return response.statusText

--- a/packages/agents-hosting/src/agent-client/agentResponseHandler.ts
+++ b/packages/agents-hosting/src/agent-client/agentResponseHandler.ts
@@ -43,6 +43,8 @@ export interface WebApp {
  * `POST /api/agentresponse/v3/conversations/{conversationId}/activities/{activityId}`
  *
  * The function handles:
+ * - Authenticating callers with JWT validation
+ * - Verifying that the authenticated caller owns the delegated conversation
  * - Normalizing incoming activity data from the request body
  * - Retrieving conversation references from conversation state
  * - Continuing conversations using the stored conversation reference

--- a/packages/agents-hosting/src/agent-client/createAgentResponseHandler.ts
+++ b/packages/agents-hosting/src/agent-client/createAgentResponseHandler.ts
@@ -19,6 +19,12 @@ const logger = debug('agents:agent-client')
 
 interface ConversationReferenceState {
   conversationReference: ConversationReference
+  expectedAgentClientId?: string
+}
+
+interface DelegatedConversationState {
+  conversationReference: ConversationReference
+  expectedAgentClientId: string
 }
 
 /**
@@ -65,21 +71,56 @@ export const createAgentResponseHandler = (
   agent: ActivityHandler,
   conversationState: ConversationState
 ): AgentResponseHandler => {
+  const appId = adapter.getClientId() ?? ''
+  const anonymousDevelopment = appId.length === 0 && process.env.NODE_ENV !== 'production'
+  if (anonymousDevelopment) {
+    emitAgentResponseWarning(
+      'The agent-response endpoint is using anonymous authentication outside production. Callback ownership cannot be cryptographically verified; configure a client ID before deployment.'
+    )
+  }
+
   return async (req: Request, res: WebResponse, params: AgentResponseHandlerParams) => {
+    let middlewareError: any
+    let nextCalled = false
+    await adapter.authorizeRequest(req, res, (err?: any) => {
+      nextCalled = true
+      middlewareError = err
+    })
+    if (middlewareError) {
+      throw middlewareError
+    }
+    if (!nextCalled || res.headersSent) {
+      return
+    }
+
     if (!req.body) {
       throw ExceptionHelper.generateException(TypeError, Errors.MissingRequestBody)
     }
     const incoming = normalizeIncomingActivity(req.body)
     const activity = Activity.fromObject(incoming)
 
-    logger.debug('received response: ', activity)
-
-    const connection = adapter.connectionManager.getDefaultConnection()
-    const appId = connection?.connectionSettings?.clientId ?? ''
+    logger.debug('received delegated agent response')
 
     const myTurnContext = new TurnContext(adapter, activity, CloudAdapter.createIdentity(appId))
     const conversationDataAccessor = conversationState.createProperty<ConversationReferenceState>(params.conversationId)
-    const conversationRefState = await conversationDataAccessor.get(myTurnContext, undefined, { channelId: activity.channelId!, conversationId: params.conversationId })
+    const incomingChannelId = activity.channelId!
+    const conversationRefState = await conversationDataAccessor.get(myTurnContext, undefined, { channelId: incomingChannelId, conversationId: params.conversationId })
+    if (!isDelegatedConversationState(conversationRefState)) {
+      res.status(403).send({ 'agent-response-auth-error': 'caller is not authorized for this conversation' })
+      return
+    }
+
+    const callerClientId = req.user?.azp ?? req.user?.appid
+    const anonymousCaller = anonymousDevelopment && req.user?.name === 'anonymous'
+    const delegatedAgentMatches = anonymousCaller || (
+      typeof callerClientId === 'string' &&
+      callerClientId.length > 0 &&
+      callerClientId.toLowerCase() === conversationRefState.expectedAgentClientId.toLowerCase()
+    )
+    if (!delegatedAgentMatches) {
+      res.status(403).send({ 'agent-response-auth-error': 'caller is not authorized for this conversation' })
+      return
+    }
 
     const callback = async (turnContext: TurnContext) => {
       activity.applyConversationReference(conversationRefState.conversationReference)
@@ -88,7 +129,7 @@ export const createAgentResponseHandler = (
       let response: unknown
       let responseContentType: string | undefined
       if (activity.type === ActivityTypes.EndOfConversation) {
-        await conversationDataAccessor.delete(turnContext, { channelId: activity.channelId!, conversationId: activity.conversation!.id })
+        await conversationState.delete(myTurnContext, { channelId: incomingChannelId, conversationId: params.conversationId })
 
         applyActivityToTurnContext(turnContext, activity)
         await agent.run(turnContext)
@@ -101,6 +142,7 @@ export const createAgentResponseHandler = (
       } else {
         response = await turnContext.sendActivity(activity)
       }
+
       if (responseContentType !== undefined) {
         res.setHeader('content-type', responseContentType)
       }
@@ -109,6 +151,18 @@ export const createAgentResponseHandler = (
 
     await adapter.continueConversation(myTurnContext.identity, conversationRefState.conversationReference, callback)
   }
+}
+
+function isDelegatedConversationState (state: ConversationReferenceState | undefined): state is DelegatedConversationState {
+  return typeof state?.conversationReference === 'object' &&
+    state.conversationReference !== null &&
+    typeof state.expectedAgentClientId === 'string' &&
+    state.expectedAgentClientId.trim().length > 0
+}
+
+function emitAgentResponseWarning (message: string): void {
+  console.warn(`[agents:agent-client] ${message}`)
+  logger.warn(message)
 }
 
 const applyActivityToTurnContext = (turnContext: TurnContext, activity: Activity) => {

--- a/packages/agents-hosting/src/agent-client/createAgentResponseHandler.ts
+++ b/packages/agents-hosting/src/agent-client/createAgentResponseHandler.ts
@@ -14,6 +14,7 @@ import { normalizeIncomingActivity } from '../activityWireCompat'
 import { Errors } from '../errorHelper'
 import { debug } from '@microsoft/agents-telemetry'
 import { ConversationState } from '../state'
+import { getAuthorizedAudience } from '../auth/jwt-middleware'
 
 const logger = debug('agents:agent-client')
 
@@ -101,7 +102,8 @@ export const createAgentResponseHandler = (
 
     logger.debug('received delegated agent response')
 
-    const myTurnContext = new TurnContext(adapter, activity, CloudAdapter.createIdentity(appId))
+    const continuationAudience = getAuthorizedAudience(req) ?? appId
+    const myTurnContext = new TurnContext(adapter, activity, CloudAdapter.createIdentity(continuationAudience))
     const conversationDataAccessor = conversationState.createProperty<ConversationReferenceState>(params.conversationId)
     const incomingChannelId = activity.channelId!
     const conversationRefState = await conversationDataAccessor.get(myTurnContext, undefined, { channelId: incomingChannelId, conversationId: params.conversationId })

--- a/packages/agents-hosting/src/auth/jwt-middleware.ts
+++ b/packages/agents-hosting/src/auth/jwt-middleware.ts
@@ -68,15 +68,21 @@ const verifyToken = async (raw: string, config: AuthConfiguration): Promise<JwtP
   if (!payload) {
     throw ExceptionHelper.generateException(Error, Errors.InvalidJwtToken)
   }
-  const audience = payload.aud
+  const audiences = Array.isArray(payload.aud)
+    ? payload.aud
+    : typeof payload.aud === 'string'
+      ? [payload.aud]
+      : []
 
   const matchingEntry = config.connections && config.connections.size > 0
-    ? [...config.connections.entries()].find(([_, configuration]) => configuration.clientId === audience)
+    ? [...config.connections.entries()].find(([_, configuration]) =>
+        typeof configuration.clientId === 'string' && audiences.includes(configuration.clientId)
+      )
     : undefined
 
   if (!matchingEntry) {
     const err = ExceptionHelper.generateException(Error, Errors.JwtAudienceMismatch)
-    logger.error(err.message, audience)
+    logger.error(err.message, audiences)
     throw err
   }
 

--- a/packages/agents-hosting/src/auth/jwt-middleware.ts
+++ b/packages/agents-hosting/src/auth/jwt-middleware.ts
@@ -15,6 +15,25 @@ import { debug } from '@microsoft/agents-telemetry'
 const logger = debug('agents:jwt-middleware')
 const jwksClients = new Map<string, JwksClient>()
 const maxJwksClients = 100
+const authorizedAudience = Symbol('authorizedAudience')
+
+interface AuthorizedRequest extends Request {
+  [authorizedAudience]?: string
+}
+
+interface VerifiedToken {
+  payload: JwtPayload
+  audience: string
+}
+
+/**
+ * Gets the configured audience selected while authorizing a request.
+ * @param req The authorized request.
+ * @returns The matched configured client ID, or `undefined` for anonymous requests.
+ */
+export function getAuthorizedAudience (req: Request): string | undefined {
+  return (req as AuthorizedRequest)[authorizedAudience]
+}
 
 /**
  * Clears process-wide JWKS clients.
@@ -59,9 +78,9 @@ export function getJwksClient (jwksUri: string): JwksClient {
  * Verifies the JWT token.
  * @param raw The raw JWT token.
  * @param config The authentication configuration.
- * @returns A promise that resolves to the JWT payload.
+ * @returns A promise that resolves to the verified payload and matched configured audience.
  */
-const verifyToken = async (raw: string, config: AuthConfiguration): Promise<JwtPayload> => {
+const verifyToken = async (raw: string, config: AuthConfiguration): Promise<VerifiedToken> => {
   const payload = jwt.decode(raw) as JwtPayload
   logger.debug('jwt.decode ', JSON.stringify(payload))
 
@@ -115,7 +134,7 @@ const verifyToken = async (raw: string, config: AuthConfiguration): Promise<JwtP
     clockTolerance: 300
   }
 
-  return await new Promise((resolve, reject) => {
+  const verifiedPayload = await new Promise<JwtPayload>((resolve, reject) => {
     jwt.verify(raw, getKey, verifyOptions, (err, user) => {
       if (err) {
         logger.error('jwt.verify ', JSON.stringify(err))
@@ -125,6 +144,10 @@ const verifyToken = async (raw: string, config: AuthConfiguration): Promise<JwtP
       resolve(user as JwtPayload)
     })
   })
+  return {
+    payload: verifiedPayload,
+    audience: authConfig.clientId!
+  }
 }
 
 /**
@@ -209,9 +232,11 @@ export const authorizeJWT = (authConfig: AuthConfiguration) => {
       const token = extractBearerToken(req.headers.authorization)
       if (token) {
         try {
-          const user = await verifyToken(token, authConfig)
-          logger.debug('token verified for ', user)
-          req.user = user
+          const verifiedToken = await verifyToken(token, authConfig)
+          logger.debug('token verified for ', verifiedToken.payload)
+          req.user = verifiedToken.payload
+          const authorizedRequest = req as AuthorizedRequest
+          authorizedRequest[authorizedAudience] = verifiedToken.audience
         } catch (err: Error | any) {
           failed = true
           logger.error(err)

--- a/packages/agents-hosting/src/cloudAdapter.ts
+++ b/packages/agents-hosting/src/cloudAdapter.ts
@@ -7,7 +7,7 @@ import { AgentHandler, INVOKE_RESPONSE_KEY } from './activityHandler'
 import { BaseAdapter } from './baseAdapter'
 import { TurnContext } from './turnContext'
 import { Request } from './auth/request'
-import { WebResponse } from './interfaces/webResponse'
+import { NextFunction, WebResponse } from './interfaces/webResponse'
 import { ConnectorClient } from './connector-client/connectorClient'
 import { AuthConfiguration, getAuthConfigWithDefaults } from './auth/authConfiguration'
 import { AuthProvider } from './auth/authProvider'
@@ -32,6 +32,7 @@ import { parseBooleanEnv, suggestClosest } from './utils/env'
 import { trace } from '@microsoft/agents-telemetry'
 import { AdapterTraceDefinitions } from './observability'
 import { applyAgenticHeaders } from './getProductInfo'
+import { authorizeJWT } from './auth/jwt-middleware'
 
 const logger = debug('agents:cloud-adapter')
 
@@ -238,6 +239,7 @@ function truncateActivityForLog (activity: unknown, max = 1024): string {
 
 export class CloudAdapter extends BaseAdapter {
   protected readonly authConfig: AuthConfiguration
+  private readonly jwtMiddleware: ReturnType<typeof authorizeJWT>
   protected _agentName?: string
 
   /**
@@ -257,6 +259,7 @@ export class CloudAdapter extends BaseAdapter {
   constructor (authConfig?: AuthConfiguration, authProvider?: AuthProvider, userTokenClient?: UserTokenClient, options?: CloudAdapterOptions) {
     super()
     this.authConfig = authConfig = getAuthConfigWithDefaults(authConfig)
+    this.jwtMiddleware = authorizeJWT(authConfig)
     this.connectionManager = new MsalConnectionManager(undefined, undefined, authConfig)
     this._options = resolveCloudAdapterOptions(options)
 
@@ -423,6 +426,24 @@ export class CloudAdapter extends BaseAdapter {
     return {
       aud: appId
     } as JwtPayload
+  }
+
+  /**
+   * Authorizes an incoming web request using this adapter's resolved authentication configuration.
+   * @param req The incoming request.
+   * @param res The outgoing response.
+   * @param next Callback invoked after successful authorization.
+   */
+  public async authorizeRequest (req: Request, res: WebResponse, next: NextFunction): Promise<void> {
+    await this.jwtMiddleware(req, res, next)
+  }
+
+  /**
+   * Gets the client ID used by this adapter's default authentication connection.
+   * @returns The configured client ID, or `undefined` for anonymous development configuration.
+   */
+  public getClientId (): string | undefined {
+    return this.authConfig.clientId
   }
 
   /**

--- a/packages/agents-hosting/test/hosting/agent-client/agentClient.test.ts
+++ b/packages/agents-hosting/test/hosting/agent-client/agentClient.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from 'node:assert'
+import { afterEach, describe, it } from 'node:test'
+import sinon from 'sinon'
+import { Activity } from '@microsoft/agents-activity'
+import {
+  AgentClient,
+  AuthConfiguration,
+  CloudAdapter,
+  ConversationState,
+  MemoryStorage,
+  MsalTokenProvider,
+  TurnContext
+} from '../../../src'
+
+const makeAuthConfig = (): AuthConfiguration => {
+  const connection = {
+    clientId: 'host-client-id',
+    tenantId: 'tenant-id',
+    issuers: ['https://api.botframework.com']
+  }
+  return {
+    ...connection,
+    connections: new Map([['serviceConnection', connection]]),
+    connectionsMap: [{ connection: 'serviceConnection', serviceUrl: '*' }]
+  }
+}
+
+describe('AgentClient conversation ownership', () => {
+  afterEach(() => {
+    sinon.restore()
+    delete process.env.DELEGATED_AGENT_endpoint
+    delete process.env.DELEGATED_AGENT_clientId
+    delete process.env.DELEGATED_AGENT_serviceUrl
+  })
+
+  it('stores the delegated agent client ID with the conversation reference', async () => {
+    process.env.DELEGATED_AGENT_endpoint = 'https://delegated.example.test/api/messages'
+    process.env.DELEGATED_AGENT_clientId = 'delegated-agent-client-id'
+    process.env.DELEGATED_AGENT_serviceUrl = 'https://delegated.example.test'
+
+    sinon.stub(MsalTokenProvider.prototype, 'getAccessToken').resolves('valid-token')
+    const fetchStub = sinon.stub(globalThis, 'fetch').resolves(new Response(undefined, { status: 200, statusText: 'OK' }))
+
+    const authConfig = makeAuthConfig()
+    const adapter = new CloudAdapter(authConfig)
+    const activity = Activity.fromObject({
+      type: 'message',
+      channelId: 'test',
+      serviceUrl: 'https://host.example.test',
+      conversation: { id: 'root-conversation' },
+      from: { id: 'user' },
+      recipient: { id: 'host' },
+      text: 'delegate this'
+    })
+    const context = new TurnContext(adapter, activity, CloudAdapter.createIdentity('host-client-id'))
+    const storage = new MemoryStorage()
+    const conversationState = new ConversationState(storage)
+
+    await new AgentClient('DELEGATED_AGENT').postActivity(activity, authConfig, conversationState, context)
+
+    const request = fetchStub.firstCall.args[1]
+    const headers = request?.headers as Record<string, string>
+    const conversationId = headers['x-ms-conversation-id']
+    const stored = await storage.read([`test/conversations/${conversationId}`])
+    const state = stored[`test/conversations/${conversationId}`] as Record<string, {
+      expectedAgentClientId?: string
+    }>
+
+    assert.strictEqual(state[conversationId].expectedAgentClientId, 'delegated-agent-client-id')
+  })
+
+  it('removes delegated conversation state when the outbound request fails', async () => {
+    process.env.DELEGATED_AGENT_endpoint = 'https://delegated.example.test/api/messages'
+    process.env.DELEGATED_AGENT_clientId = 'delegated-agent-client-id'
+    process.env.DELEGATED_AGENT_serviceUrl = 'https://delegated.example.test'
+
+    sinon.stub(MsalTokenProvider.prototype, 'getAccessToken').resolves('valid-token')
+    const fetchStub = sinon.stub(globalThis, 'fetch').resolves(new Response(undefined, { status: 500, statusText: 'Failed' }))
+
+    const authConfig = makeAuthConfig()
+    const adapter = new CloudAdapter(authConfig)
+    const activity = Activity.fromObject({
+      type: 'message',
+      channelId: 'test',
+      serviceUrl: 'https://host.example.test',
+      conversation: { id: 'root-conversation' },
+      from: { id: 'user' },
+      recipient: { id: 'host' }
+    })
+    const context = new TurnContext(adapter, activity, CloudAdapter.createIdentity('host-client-id'))
+    const memory: Record<string, string> = {}
+    const storage = new MemoryStorage(memory)
+    const conversationState = new ConversationState(storage)
+    const rootState = conversationState.createProperty<string>('root')
+    await rootState.set(context, 'preserved')
+    await conversationState.saveChanges(context)
+
+    await assert.rejects(
+      new AgentClient('DELEGATED_AGENT').postActivity(activity, authConfig, conversationState, context)
+    )
+
+    const request = fetchStub.firstCall.args[1]
+    const headers = request?.headers as Record<string, string>
+    const conversationId = headers['x-ms-conversation-id']
+    assert.deepStrictEqual(await storage.read([`test/conversations/${conversationId}`]), {})
+    assert.strictEqual(await rootState.get(context), 'preserved')
+    assert.deepStrictEqual(Object.keys(memory), ['test/conversations/root-conversation/'])
+  })
+
+  it('removes delegated state after a network failure without changing caller state', async () => {
+    process.env.DELEGATED_AGENT_endpoint = 'https://delegated.example.test/api/messages'
+    process.env.DELEGATED_AGENT_clientId = 'delegated-agent-client-id'
+    process.env.DELEGATED_AGENT_serviceUrl = 'https://delegated.example.test'
+
+    sinon.stub(MsalTokenProvider.prototype, 'getAccessToken').resolves('valid-token')
+    sinon.stub(globalThis, 'fetch').rejects(new Error('network failure'))
+
+    const authConfig = makeAuthConfig()
+    const adapter = new CloudAdapter(authConfig)
+    const activity = Activity.fromObject({
+      type: 'message',
+      channelId: 'test',
+      serviceUrl: 'https://host.example.test',
+      conversation: { id: 'root-conversation' },
+      from: { id: 'user' },
+      recipient: { id: 'host' }
+    })
+    const context = new TurnContext(adapter, activity, CloudAdapter.createIdentity('host-client-id'))
+    const memory: Record<string, string> = {}
+    const storage = new MemoryStorage(memory)
+    const conversationState = new ConversationState(storage)
+    const rootState = conversationState.createProperty<string>('root')
+    await rootState.set(context, 'preserved')
+    await conversationState.saveChanges(context)
+
+    await assert.rejects(
+      new AgentClient('DELEGATED_AGENT').postActivity(activity, authConfig, conversationState, context),
+      /network failure/
+    )
+
+    assert.strictEqual(await rootState.get(context), 'preserved')
+    assert.deepStrictEqual(Object.keys(memory), ['test/conversations/root-conversation/'])
+  })
+
+  it('does not persist delegated state when token acquisition fails', async () => {
+    process.env.DELEGATED_AGENT_endpoint = 'https://delegated.example.test/api/messages'
+    process.env.DELEGATED_AGENT_clientId = 'delegated-agent-client-id'
+    process.env.DELEGATED_AGENT_serviceUrl = 'https://delegated.example.test'
+
+    sinon.stub(MsalTokenProvider.prototype, 'getAccessToken').rejects(new Error('token failure'))
+    const fetchStub = sinon.stub(globalThis, 'fetch')
+
+    const authConfig = makeAuthConfig()
+    const adapter = new CloudAdapter(authConfig)
+    const activity = Activity.fromObject({
+      type: 'message',
+      channelId: 'test',
+      serviceUrl: 'https://host.example.test',
+      conversation: { id: 'root-conversation' },
+      from: { id: 'user' },
+      recipient: { id: 'host' }
+    })
+    const context = new TurnContext(adapter, activity, CloudAdapter.createIdentity('host-client-id'))
+    const memory: Record<string, string> = {}
+    const storage = new MemoryStorage(memory)
+    const conversationState = new ConversationState(storage)
+    const rootState = conversationState.createProperty<string>('root')
+    await rootState.set(context, 'preserved')
+    await conversationState.saveChanges(context)
+
+    await assert.rejects(
+      new AgentClient('DELEGATED_AGENT').postActivity(activity, authConfig, conversationState, context),
+      /token failure/
+    )
+
+    assert.strictEqual(fetchStub.called, false)
+    assert.strictEqual(await rootState.get(context), 'preserved')
+    assert.deepStrictEqual(Object.keys(memory), ['test/conversations/root-conversation/'])
+  })
+})

--- a/packages/agents-hosting/test/hosting/agent-client/createAgentResponseHandler.test.ts
+++ b/packages/agents-hosting/test/hosting/agent-client/createAgentResponseHandler.test.ts
@@ -46,10 +46,21 @@ const makeAuthConfig = (): AuthConfiguration => {
     tenantId: 'tenant-id',
     issuers: ['https://api.botframework.com']
   }
+  const alternateConnection = {
+    clientId: 'alternate-host-client-id',
+    tenantId: 'tenant-id',
+    issuers: ['https://api.botframework.com']
+  }
   return {
     ...connection,
-    connections: new Map([['serviceConnection', connection]]),
-    connectionsMap: [{ connection: 'serviceConnection', serviceUrl: '*' }]
+    connections: new Map([
+      ['serviceConnection', connection],
+      ['alternateConnection', alternateConnection]
+    ]),
+    connectionsMap: [
+      { connection: 'serviceConnection', serviceUrl: '*' },
+      { connection: 'alternateConnection', serviceUrl: 'https://alternate.example.test' }
+    ]
   }
 }
 
@@ -147,19 +158,14 @@ describe('createAgentResponseHandler authentication', () => {
     assert.strictEqual((stored['test/conversations/c1'] as any).c1.expectedAgentClientId, 'delegated-agent-client-id')
   })
 
-  it('does not repeat audience validation after adapter authorization', async () => {
+  it('continues with the host audience selected during adapter authorization', async () => {
+    stubValidJwt('delegated-agent-client-id', ['unrelated-audience', 'alternate-host-client-id'])
     const storage = new MemoryStorage()
     await seedConversation(storage, 'delegated-agent-client-id')
     const { handler, adapter } = makeHandler(new ActivityHandler(), new ConversationState(storage))
-    sinon.stub(adapter, 'authorizeRequest').callsFake(async (req, _res, next) => {
-      req.user = {
-        aud: 'alternate-configured-host-client-id',
-        azp: 'delegated-agent-client-id'
-      }
-      next()
-    })
     const sendActivity = sinon.stub(TurnContext.prototype, 'sendActivity').resolves({ id: 'response' })
     sinon.stub(adapter, 'continueConversation').callsFake(async (...args: any[]) => {
+      assert.strictEqual(args[0].aud, 'alternate-host-client-id')
       const callback = args[2]
       const context = new TurnContext(adapter, Activity.fromObject({
         type: 'event',

--- a/packages/agents-hosting/test/hosting/agent-client/createAgentResponseHandler.test.ts
+++ b/packages/agents-hosting/test/hosting/agent-client/createAgentResponseHandler.test.ts
@@ -9,15 +9,20 @@
  */
 
 import { strict as assert } from 'assert'
-import { describe, it } from 'node:test'
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import sinon from 'sinon'
+import jwt from 'jsonwebtoken'
+import { Activity, ActivityTypes } from '@microsoft/agents-activity'
 import {
   ActivityHandler,
+  AuthConfiguration,
   CloudAdapter,
   ConversationState,
   MemoryStorage,
   createAgentResponseHandler,
   HostingErrors,
   Request,
+  TurnContext,
   WebResponse
 } from '../../../src'
 
@@ -25,27 +30,367 @@ const makeRes = (): WebResponse => {
   const r: any = {
     headersSent: false,
     writableEnded: false,
-    status () { return r },
+    statusCode: undefined,
+    body: undefined,
+    status (code: number) { r.statusCode = code; return r },
     setHeader () { return r },
-    send () { r.headersSent = true; return r },
+    send (body: unknown) { r.body = body; r.headersSent = true; return r },
     end () { r.writableEnded = true; return r }
   }
   return r
 }
 
-const makeHandler = () => {
-  const adapter = new CloudAdapter({ clientId: 'test', tenantId: 't', issuers: [], connections: new Map() })
-  const conversationState = new ConversationState(new MemoryStorage())
-  return createAgentResponseHandler(adapter, new ActivityHandler(), conversationState)
+const makeAuthConfig = (): AuthConfiguration => {
+  const connection = {
+    clientId: 'host-client-id',
+    tenantId: 'tenant-id',
+    issuers: ['https://api.botframework.com']
+  }
+  return {
+    ...connection,
+    connections: new Map([['serviceConnection', connection]]),
+    connectionsMap: [{ connection: 'serviceConnection', serviceUrl: '*' }]
+  }
 }
 
+const makeHandler = (agent = new ActivityHandler(), conversationState = new ConversationState(new MemoryStorage())) => {
+  const authConfig = makeAuthConfig()
+  const adapter = new CloudAdapter(authConfig)
+  return {
+    handler: createAgentResponseHandler(adapter, agent, conversationState),
+    adapter
+  }
+}
+
+const stubValidJwt = (callerClientId: string, audience: string | string[] = 'host-client-id') => {
+  sinon.stub(jwt, 'decode').returns({
+    aud: audience,
+    iss: 'https://api.botframework.com'
+  })
+  sinon.stub(jwt, 'verify').callsFake((token, secretOrPublicKey, options, callback) => {
+    if (callback) {
+      callback(null, { aud: audience, azp: callerClientId })
+    }
+  })
+}
+
+const makeRequest = (body?: Record<string, unknown>): Request => ({
+  headers: { authorization: ['Bear', 'er valid-token'].join('') },
+  method: 'POST',
+  body
+})
+
+const conversationReference = {
+  activityId: 'root-activity',
+  user: { id: 'user' },
+  bot: { id: 'host' },
+  conversation: { id: 'root-conversation' },
+  channelId: 'test',
+  serviceUrl: 'https://example.test'
+}
+
+const seedConversation = async (storage: MemoryStorage, expectedAgentClientId?: string) => {
+  await storage.write({
+    'test/conversations/c1': {
+      c1: {
+        conversationReference,
+        nameRequested: false,
+        expectedAgentClientId
+      }
+    }
+  })
+}
+
+describe('createAgentResponseHandler authentication', () => {
+  beforeEach(() => {
+    sinon.restore()
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('returns 401 before processing a request without credentials', async () => {
+    const { handler } = makeHandler()
+    const res = makeRes() as WebResponse & { statusCode?: number, body?: unknown }
+
+    await handler({ headers: {}, method: 'POST', body: { type: 'message' } }, res, { conversationId: 'c1', activityId: 'a1' })
+
+    assert.strictEqual(res.statusCode, 401)
+    assert.deepStrictEqual(res.body, { 'jwt-auth-error': 'authorization header not found' })
+  })
+
+  it('returns 403 without invoking agent logic when the caller does not own the conversation', async () => {
+    stubValidJwt('attacker-client-id')
+    const storage = new MemoryStorage()
+    await seedConversation(storage, 'delegated-agent-client-id')
+    const conversationState = new ConversationState(storage)
+    let invoked = false
+    const agent = new ActivityHandler()
+    agent.onEndOfConversation(async (_context, next) => {
+      invoked = true
+      await next()
+    })
+    const { handler } = makeHandler(agent, conversationState)
+    const res = makeRes() as WebResponse & { statusCode?: number, body?: unknown }
+
+    await handler(makeRequest({
+      type: ActivityTypes.EndOfConversation,
+      channelId: 'test',
+      conversation: { id: 'c1' }
+    }), res, { conversationId: 'c1', activityId: 'a1' })
+
+    assert.strictEqual(res.statusCode, 403)
+    assert.deepStrictEqual(res.body, { 'agent-response-auth-error': 'caller is not authorized for this conversation' })
+    assert.strictEqual(invoked, false)
+    const stored = await storage.read(['test/conversations/c1'])
+    assert.strictEqual((stored['test/conversations/c1'] as any).c1.expectedAgentClientId, 'delegated-agent-client-id')
+  })
+
+  it('does not repeat audience validation after adapter authorization', async () => {
+    const storage = new MemoryStorage()
+    await seedConversation(storage, 'delegated-agent-client-id')
+    const { handler, adapter } = makeHandler(new ActivityHandler(), new ConversationState(storage))
+    sinon.stub(adapter, 'authorizeRequest').callsFake(async (req, _res, next) => {
+      req.user = {
+        aud: 'alternate-configured-host-client-id',
+        azp: 'delegated-agent-client-id'
+      }
+      next()
+    })
+    const sendActivity = sinon.stub(TurnContext.prototype, 'sendActivity').resolves({ id: 'response' })
+    sinon.stub(adapter, 'continueConversation').callsFake(async (...args: any[]) => {
+      const callback = args[2]
+      const context = new TurnContext(adapter, Activity.fromObject({
+        type: 'event',
+        channelId: 'test',
+        serviceUrl: 'https://example.test',
+        conversation: { id: 'root-conversation' },
+        from: { id: 'user' },
+        recipient: { id: 'host' }
+      }), CloudAdapter.createIdentity('host-client-id'))
+      await callback(context)
+    })
+    const res = makeRes() as WebResponse & { statusCode?: number }
+
+    await handler(makeRequest({
+      type: 'message',
+      channelId: 'test',
+      conversation: { id: 'c1' }
+    }), res, { conversationId: 'c1', activityId: 'a1' })
+
+    assert.strictEqual(res.statusCode, 200)
+    assert.strictEqual(sendActivity.calledOnce, true)
+  })
+
+  it('returns 403 for legacy conversation state without an expected agent client ID', async () => {
+    stubValidJwt('delegated-agent-client-id')
+    const storage = new MemoryStorage()
+    await seedConversation(storage)
+    const warning = sinon.stub(console, 'warn')
+    const { handler } = makeHandler(new ActivityHandler(), new ConversationState(storage))
+    const res = makeRes() as WebResponse & { statusCode?: number }
+
+    await handler(makeRequest({
+      type: 'message',
+      channelId: 'test',
+      conversation: { id: 'c1' }
+    }), res, { conversationId: 'c1', activityId: 'a1' })
+
+    assert.strictEqual(res.statusCode, 403)
+    assert.strictEqual(warning.called, false)
+  })
+
+  it('returns 403 for missing conversation state without reporting it as legacy', async () => {
+    stubValidJwt('delegated-agent-client-id')
+    const warning = sinon.stub(console, 'warn')
+    const { handler } = makeHandler()
+    const res = makeRes() as WebResponse & { statusCode?: number }
+
+    await handler(makeRequest({
+      type: 'message',
+      channelId: 'test',
+      conversation: { id: 'c1' }
+    }), res, { conversationId: 'c1', activityId: 'a1' })
+
+    assert.strictEqual(res.statusCode, 403)
+    assert.strictEqual(warning.called, false)
+  })
+
+  it('returns 403 for malformed conversation state', async () => {
+    stubValidJwt('delegated-agent-client-id')
+    const storage = new MemoryStorage()
+    await storage.write({
+      'test/conversations/c1': {
+        c1: {
+          expectedAgentClientId: 'delegated-agent-client-id'
+        }
+      }
+    })
+    const { handler } = makeHandler(new ActivityHandler(), new ConversationState(storage))
+    const res = makeRes() as WebResponse & { statusCode?: number }
+
+    await handler(makeRequest({
+      type: 'message',
+      channelId: 'test',
+      conversation: { id: 'c1' }
+    }), res, { conversationId: 'c1', activityId: 'a1' })
+
+    assert.strictEqual(res.statusCode, 403)
+  })
+
+  it('processes the callback when the authenticated caller owns the conversation', async () => {
+    stubValidJwt('DELEGATED-AGENT-CLIENT-ID')
+    const storage = new MemoryStorage()
+    await seedConversation(storage, 'delegated-agent-client-id')
+    let invoked = false
+    const agent = new ActivityHandler()
+    agent.onEndOfConversation(async (_context, next) => {
+      invoked = true
+      await next()
+    })
+    const { handler, adapter } = makeHandler(agent, new ConversationState(storage))
+    sinon.stub(adapter, 'continueConversation').callsFake(async (...args: any[]) => {
+      const callback = args[2]
+      const context = new TurnContext(adapter, Activity.fromObject({
+        type: 'event',
+        channelId: 'test',
+        serviceUrl: 'https://example.test',
+        conversation: { id: 'root-conversation' },
+        from: { id: 'user' },
+        recipient: { id: 'host' }
+      }), CloudAdapter.createIdentity('host-client-id'))
+      await callback(context)
+    })
+    const res = makeRes() as WebResponse & { statusCode?: number }
+
+    await handler(makeRequest({
+      type: ActivityTypes.EndOfConversation,
+      channelId: 'test',
+      conversation: { id: 'c1' }
+    }), res, { conversationId: 'c1', activityId: 'a1' })
+
+    assert.strictEqual(res.statusCode, 200)
+    assert.strictEqual(invoked, true)
+    assert.deepStrictEqual(await storage.read(['test/conversations/c1']), {})
+  })
+
+  it('preserves anonymous callbacks outside production and emits a startup warning', async () => {
+    const originalNodeEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+    const storage = new MemoryStorage()
+    await seedConversation(storage, 'delegated-agent-client-id')
+    const { adapter } = makeHandler(new ActivityHandler(), new ConversationState(storage))
+    sinon.stub(adapter, 'getClientId').returns(undefined)
+    sinon.stub(adapter, 'authorizeRequest').callsFake(async (req, _res, next) => {
+      req.user = { name: 'anonymous' }
+      next()
+    })
+    const warning = sinon.stub(console, 'warn')
+    const handler = createAgentResponseHandler(adapter, new ActivityHandler(), new ConversationState(storage))
+    createAgentResponseHandler(adapter, new ActivityHandler(), new ConversationState(storage))
+    assert.strictEqual(warning.callCount, 2)
+    const sendActivity = sinon.stub(TurnContext.prototype, 'sendActivity').resolves({ id: 'response' })
+    sinon.stub(adapter, 'continueConversation').callsFake(async (...args: any[]) => {
+      const callback = args[2]
+      const context = new TurnContext(adapter, Activity.fromObject({
+        type: 'event',
+        channelId: 'test',
+        serviceUrl: 'https://example.test',
+        conversation: { id: 'root-conversation' },
+        from: { id: 'user' },
+        recipient: { id: 'host' }
+      }), CloudAdapter.createIdentity(''))
+      await callback(context)
+    })
+    const res = makeRes() as WebResponse & { statusCode?: number }
+
+    try {
+      await handler({
+        headers: {},
+        method: 'POST',
+        body: {
+          type: 'message',
+          channelId: 'test',
+          conversation: { id: 'c1' }
+        }
+      }, res, { conversationId: 'c1', activityId: 'a1' })
+
+      assert.strictEqual(res.statusCode, 200)
+      assert.strictEqual(sendActivity.calledOnce, true)
+      assert(warning.calledWithMatch('anonymous authentication outside production'))
+    } finally {
+      if (originalNodeEnv === undefined) {
+        delete process.env.NODE_ENV
+      } else {
+        process.env.NODE_ENV = originalNodeEnv
+      }
+    }
+  })
+
+  it('rejects anonymous callbacks in production', async () => {
+    const originalNodeEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    const storage = new MemoryStorage()
+    await seedConversation(storage, 'delegated-agent-client-id')
+    const { adapter } = makeHandler(new ActivityHandler(), new ConversationState(storage))
+    sinon.stub(adapter, 'getClientId').returns(undefined)
+    sinon.stub(adapter, 'authorizeRequest').callsFake(async (req, _res, next) => {
+      req.user = { name: 'anonymous' }
+      next()
+    })
+    const warning = sinon.stub(console, 'warn')
+    let continued = false
+    sinon.stub(adapter, 'continueConversation').callsFake(async () => {
+      continued = true
+    })
+    const handler = createAgentResponseHandler(adapter, new ActivityHandler(), new ConversationState(storage))
+    const res = makeRes() as WebResponse & { statusCode?: number }
+
+    try {
+      await handler({
+        headers: {},
+        method: 'POST',
+        body: {
+          type: 'message',
+          channelId: 'test',
+          conversation: { id: 'c1' }
+        }
+      }, res, { conversationId: 'c1', activityId: 'a1' })
+
+      assert.strictEqual(res.statusCode, 403)
+      assert.strictEqual(continued, false)
+      assert.strictEqual(warning.called, false)
+    } finally {
+      if (originalNodeEnv === undefined) {
+        delete process.env.NODE_ENV
+      } else {
+        process.env.NODE_ENV = originalNodeEnv
+      }
+    }
+  })
+})
+
 describe('createAgentResponseHandler missing-body guard', () => {
+  beforeEach(() => {
+    stubValidJwt('delegated-agent-client-id')
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  const makeMissingBodyHandler = () => {
+    const { handler } = makeHandler()
+    return handler
+  }
+
   const params = { conversationId: 'c1', activityId: 'a1' }
 
   it('throws MissingRequestBody when req.body is undefined', async () => {
-    const handler = makeHandler()
+    const handler = makeMissingBodyHandler()
     await assert.rejects(
-      () => handler({ headers: {}, method: 'POST' } as Request, makeRes(), params),
+      () => handler(makeRequest(), makeRes(), params),
       (err: any) => {
         assert.strictEqual(err.code, HostingErrors.MissingRequestBody.code)
         return true
@@ -54,9 +399,9 @@ describe('createAgentResponseHandler missing-body guard', () => {
   })
 
   it('throws MissingRequestBody when req.body is null', async () => {
-    const handler = makeHandler()
+    const handler = makeMissingBodyHandler()
     await assert.rejects(
-      () => handler({ headers: {}, method: 'POST', body: null } as unknown as Request, makeRes(), params),
+      () => handler({ ...makeRequest(), body: null } as unknown as Request, makeRes(), params),
       (err: any) => {
         assert.strictEqual(err.code, HostingErrors.MissingRequestBody.code)
         return true

--- a/packages/agents-hosting/test/hosting/jwt-middleware.test.ts
+++ b/packages/agents-hosting/test/hosting/jwt-middleware.test.ts
@@ -70,6 +70,27 @@ describe('authorizeJWT', () => {
     verifyStub.restore()
   })
 
+  it('should authenticate when the configured client ID is one of multiple token audiences', async () => {
+    const token = 'valid-token'
+    const audiences = ['secondary-audience', config.clientId!]
+    req.headers.authorization = ['Bear', 'er ', token].join('')
+
+    const decodeStub = sinon.stub(jwt, 'decode').returns({ aud: audiences })
+    const verifyStub = sinon.stub(jwt, 'verify').callsFake((token, secretOrPublicKey, options, callback) => {
+      if (callback) {
+        callback(null, { aud: audiences })
+      }
+    })
+
+    await authorizeJWT(config)(req as Request, res as Response, next)
+
+    assert((next as sinon.SinonStub).calledOnce)
+    assert((res.status as sinon.SinonStub).notCalled)
+
+    decodeStub.restore()
+    verifyStub.restore()
+  })
+
   it('should respond with 401 if token is missing', async () => {
     await authorizeJWT(config)(req as Request, res as Response, next)
 

--- a/test-agents/a2a-agent/.env.cat.TEMPLATE
+++ b/test-agents/a2a-agent/.env.cat.TEMPLATE
@@ -1,0 +1,9 @@
+# Copy to .env.cat
+PORT=3979
+
+connections__serviceConnection__settings__clientId=<wise-cat-client-id>
+connections__serviceConnection__settings__clientSecret=<wise-cat-client-secret>
+connections__serviceConnection__settings__tenantId=<tenant-id>
+
+connectionsMap__0__connection=serviceConnection
+connectionsMap__0__serviceUrl=*

--- a/test-agents/a2a-agent/.env.human.TEMPLATE
+++ b/test-agents/a2a-agent/.env.human.TEMPLATE
@@ -1,0 +1,13 @@
+# Copy to .env.human
+PORT=3978
+
+connections__serviceConnection__settings__clientId=<human-agent-client-id>
+connections__serviceConnection__settings__clientSecret=<human-agent-client-secret>
+connections__serviceConnection__settings__tenantId=<tenant-id>
+
+connectionsMap__0__connection=serviceConnection
+connectionsMap__0__serviceUrl=*
+
+WiseCat_endpoint=http://localhost:3979/api/messages
+WiseCat_clientId=<wise-cat-client-id>
+WiseCat_serviceUrl=http://localhost:3978/api/agentresponse

--- a/test-agents/a2a-agent/.env.smoke.TEMPLATE
+++ b/test-agents/a2a-agent/.env.smoke.TEMPLATE
@@ -1,0 +1,9 @@
+# Copy to .env.smoke
+TENANT_ID=<tenant-id>
+HUMAN_CLIENT_ID=<human-agent-client-id>
+HUMAN_CLIENT_SECRET=<human-agent-client-secret>
+CAT_CLIENT_ID=<wise-cat-client-id>
+CAT_CLIENT_SECRET=<wise-cat-client-secret>
+
+HUMAN_ENDPOINT=http://localhost:3978/api/messages
+MOCK_CHANNEL_PORT=3980

--- a/test-agents/a2a-agent/README.md
+++ b/test-agents/a2a-agent/README.md
@@ -1,0 +1,98 @@
+# Authenticated agent-to-agent cat smoke test
+
+This test agent pair demonstrates the authenticated callback pattern:
+
+1. **I'll Ask My Cat** receives a user message.
+2. It delegates the activity to **The Wise Cat** with `AgentClient`.
+3. The Wise Cat replies from a cat's point of view.
+4. The reply is posted to the first agent's authenticated `configureResponseController` route.
+5. The first agent forwards the reply to the original conversation.
+
+The smoke client verifies that:
+
+- a request without a token is rejected with `401`;
+- a valid token for the wrong audience is rejected with `401`;
+- a valid token for the human agent is accepted;
+- the Wise Cat's independently authenticated callback reaches the original conversation.
+
+## Why authentication looks different in each agent
+
+Both agents use the same SDK authentication stack, but they use different hosting
+surfaces:
+
+- **I'll Ask My Cat configures authentication explicitly.** It creates the
+  `AuthConfiguration`, `CloudAdapter`, Express `/api/messages` route, and
+  `configureResponseController` callback route itself. It needs access to the
+  same adapter, authentication configuration, and `ConversationState` when
+  `AgentClient` delegates work and when the Wise Cat posts its response. The
+  messages route calls `adapter.authorizeRequest` explicitly; the response
+  controller calls that same adapter method internally so a host cannot
+  accidentally register an unauthenticated callback.
+- **The Wise Cat configures authentication implicitly through `startServer`.**
+  `startServer` loads the Cat agent's connection settings from `.env.cat`,
+  creates its `CloudAdapter`, and applies JWT validation to `/api/messages`.
+  When the Cat calls `context.sendActivity()`, that adapter automatically
+  acquires a token for the Human agent and posts to the activity's callback
+  `serviceUrl`.
+
+The Cat is not anonymous or less protected; its setup is simply hidden behind
+the higher-level `startServer` helper. The Human agent uses lower-level hosting
+APIs because it must expose both the normal message endpoint and the additional
+agent-response endpoint.
+
+For the Human callback endpoint, the shared `CloudAdapter` validates the inbound
+JWT once against its configured host connections. The callback handler then
+checks that the token's caller application is the Wise Cat client ID stored when
+the delegated conversation was created. The conversation ID routes the callback;
+it is not treated as an authentication secret.
+
+## Microsoft Entra setup
+
+Create two confidential-client app registrations in the same tenant:
+
+- **Human agent** — the "I'll Ask My Cat" host.
+- **Wise Cat agent** — the delegated agent and smoke-test caller.
+
+Expose each application as an API. Grant and admin-consent application permissions in both directions:
+
+- Human agent may request an application token for the Wise Cat API.
+- Wise Cat may request an application token for the Human agent API.
+
+The token audience used by this SDK is the target application's client ID. Ensure each app registration accepts client-credential tokens requested with `<target-client-id>/.default`.
+
+The Human agent also sends the final activity through the stored conversation reference. For a real channel, configure the normal Bot Service permissions for the Human agent. The included mock channel accepts the outbound callback and does not validate that channel token.
+
+## Configure
+
+From `test-agents/a2a-agent`, copy and fill in:
+
+```powershell
+Copy-Item .env.human.TEMPLATE .env.human
+Copy-Item .env.cat.TEMPLATE .env.cat
+Copy-Item .env.smoke.TEMPLATE .env.smoke
+```
+
+The smoke client uses both app secrets to request one deliberately wrong-audience
+token and one valid token. Do not commit the populated `.env.*` files.
+
+## Run
+
+Use three terminals:
+
+```powershell
+npm run start:human --workspace a2a-agent
+```
+
+```powershell
+npm run start:cat --workspace a2a-agent
+```
+
+```powershell
+npm run smoke --workspace a2a-agent
+```
+
+A successful run reports both rejected auth checks and ends with:
+
+```text
+A2A cat smoke test passed: invalid auth was rejected and the authenticated delegated response returned.
+```

--- a/test-agents/a2a-agent/README.md
+++ b/test-agents/a2a-agent/README.md
@@ -38,7 +38,8 @@ surfaces:
 The Cat is not anonymous or less protected; its setup is simply hidden behind
 the higher-level `startServer` helper. The Human agent uses lower-level hosting
 APIs because it must expose both the normal message endpoint and the additional
-agent-response endpoint.
+agent-response endpoint. Both agents limit authenticated requests to 100 per
+15-minute window.
 
 For the Human callback endpoint, the shared `CloudAdapter` validates the inbound
 JWT once against its configured host connections. The callback handler then

--- a/test-agents/a2a-agent/package.json
+++ b/test-agents/a2a-agent/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "a2a-agent",
+  "version": "1.0.0",
+  "private": true,
+  "author": "Microsoft",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/sageAgent.js",
+  "scripts": {
+    "build": "tsc --build",
+    "prestart:human": "npm run build",
+    "start:human": "node --env-file .env.human ./dist/sageAgent.js",
+    "prestart:cat": "npm run build",
+    "start:cat": "node --env-file .env.cat ./dist/wiseCatAgent.js",
+    "presmoke": "npm run build",
+    "smoke": "node --env-file .env.smoke ./dist/smokeClient.js"
+  },
+  "dependencies": {
+    "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
+    "@microsoft/agents-hosting-express": "file:../../packages/agents-hosting-express",
+    "express": "5.2.1"
+  }
+}

--- a/test-agents/a2a-agent/package.json
+++ b/test-agents/a2a-agent/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
     "@microsoft/agents-hosting-express": "file:../../packages/agents-hosting-express",
-    "express": "5.2.1"
+    "express": "5.2.1",
+    "express-rate-limit": "8.5.2"
   }
 }

--- a/test-agents/a2a-agent/src/sageAgent.ts
+++ b/test-agents/a2a-agent/src/sageAgent.ts
@@ -4,6 +4,7 @@
  */
 
 import express, { Response } from 'express'
+import rateLimit from 'express-rate-limit'
 import {
   ActivityHandler,
   AgentClient,
@@ -44,11 +45,16 @@ const adapter = new CloudAdapter(authConfig)
 const authorizeRequest = adapter.authorizeRequest.bind(adapter)
 const agent = new AskMyCatAgent(authConfig, conversationState)
 const app = express()
+const requestRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100
+})
 
 app.use(express.json())
-app.post('/api/messages', authorizeRequest, async (req: Request, res: Response) => {
+app.post('/api/messages', requestRateLimiter, authorizeRequest, async (req: Request, res: Response) => {
   await adapter.process(req, res, async (context) => await agent.run(context))
 })
+app.use('/api/agentresponse', requestRateLimiter)
 // The response controller applies the same adapter-owned authorization internally.
 configureResponseController(app, adapter, agent, conversationState)
 

--- a/test-agents/a2a-agent/src/sageAgent.ts
+++ b/test-agents/a2a-agent/src/sageAgent.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import express, { Response } from 'express'
+import {
+  ActivityHandler,
+  AgentClient,
+  AuthConfiguration,
+  CloudAdapter,
+  configureResponseController,
+  ConversationState,
+  loadAuthConfigFromEnv,
+  MemoryStorage,
+  Request
+} from '@microsoft/agents-hosting'
+
+class AskMyCatAgent extends ActivityHandler {
+  constructor (
+    private readonly authConfig: AuthConfiguration,
+    private readonly conversationState: ConversationState
+  ) {
+    super()
+
+    this.onMessage(async (context, next) => {
+      await context.sendActivity("I'll ask my cat. She has strong opinions and excellent whiskers.")
+
+      const catClient = new AgentClient('WiseCat')
+      await catClient.postActivity(context.activity, this.authConfig, this.conversationState, context)
+      await next()
+    })
+
+    this.onEndOfConversation(async (context, next) => {
+      console.log(`The Wise Cat ended the delegated conversation: ${context.activity.text ?? 'no final message'}`)
+      await next()
+    })
+  }
+}
+
+const authConfig = loadAuthConfigFromEnv()
+const conversationState = new ConversationState(new MemoryStorage())
+const adapter = new CloudAdapter(authConfig)
+const authorizeRequest = adapter.authorizeRequest.bind(adapter)
+const agent = new AskMyCatAgent(authConfig, conversationState)
+const app = express()
+
+app.use(express.json())
+app.post('/api/messages', authorizeRequest, async (req: Request, res: Response) => {
+  await adapter.process(req, res, async (context) => await agent.run(context))
+})
+// The response controller applies the same adapter-owned authorization internally.
+configureResponseController(app, adapter, agent, conversationState)
+
+const port = Number(process.env.PORT ?? 3978)
+app.listen(port, () => {
+  console.log(`I'll Ask My Cat agent listening on http://localhost:${port}/api/messages`)
+})

--- a/test-agents/a2a-agent/src/smokeClient.ts
+++ b/test-agents/a2a-agent/src/smokeClient.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import express from 'express'
+import { randomUUID } from 'node:crypto'
+
+interface TokenResponse {
+  access_token?: string
+  error?: string
+  error_description?: string
+}
+
+interface CapturedActivity {
+  text?: string
+  type?: string
+}
+
+const tenantId = requireEnv('TENANT_ID')
+const humanClientId = requireEnv('HUMAN_CLIENT_ID')
+const humanClientSecret = requireEnv('HUMAN_CLIENT_SECRET')
+const catClientId = requireEnv('CAT_CLIENT_ID')
+const catClientSecret = requireEnv('CAT_CLIENT_SECRET')
+const humanEndpoint = process.env.HUMAN_ENDPOINT ?? 'http://localhost:3978/api/messages'
+const channelPort = Number(process.env.MOCK_CHANNEL_PORT ?? 3980)
+const channelServiceUrl = `http://localhost:${channelPort}`
+const conversationId = `a2a-agent-${randomUUID()}`
+const captured: CapturedActivity[] = []
+
+const channel = express()
+channel.use(express.json())
+
+const captureActivity = (body: CapturedActivity, res: express.Response) => {
+  captured.push(body)
+  console.log(`Mock channel received: ${body.text ?? body.type ?? 'activity'}`)
+  res.status(200).send({ id: randomUUID() })
+}
+
+channel.post('/v3/conversations/:conversationId/activities', (req, res) => captureActivity(req.body, res))
+channel.post('/v3/conversations/:conversationId/activities/:activityId', (req, res) => captureActivity(req.body, res))
+
+const server = channel.listen(channelPort, async () => {
+  try {
+    console.log(`Mock channel listening on ${channelServiceUrl}`)
+    const activity = {
+      type: 'message',
+      id: randomUUID(),
+      timestamp: new Date().toISOString(),
+      serviceUrl: channelServiceUrl,
+      channelId: 'a2a-agent',
+      from: { id: 'smoke-user', name: 'Smoke Tester' },
+      recipient: { id: humanClientId, name: "I'll Ask My Cat" },
+      conversation: { id: conversationId },
+      text: "I'll ask my cat: what is the secret to a good afternoon?"
+    }
+
+    const missingAuth = await postActivity(activity)
+    assertStatus(missingAuth, 401, 'missing Authorization header')
+
+    const wrongAudienceToken = await getAppToken(catClientId, humanClientId, humanClientSecret)
+    const wrongAudience = await postActivity(activity, wrongAudienceToken)
+    assertStatus(wrongAudience, 401, 'token with the Wise Cat audience')
+
+    const validToken = await getAppToken(humanClientId, catClientId, catClientSecret)
+    const accepted = await postActivity(activity, validToken)
+    if (!accepted.ok) {
+      throw new Error(`Human agent rejected the valid request: ${accepted.status} ${await accepted.text()}`)
+    }
+
+    await waitForWiseCat()
+    console.log('A2A cat smoke test passed: invalid auth was rejected and the authenticated delegated response returned.')
+  } catch (error) {
+    console.error(error)
+    process.exitCode = 1
+  } finally {
+    server.close()
+  }
+})
+
+async function getAppToken (audience: string, clientId: string, clientSecret: string): Promise<string> {
+  const tokenEndpoint = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: 'client_credentials',
+    scope: `${audience}/.default`
+  })
+  const response = await fetch(tokenEndpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body
+  })
+  const token = await response.json() as TokenResponse
+  if (!response.ok || !token.access_token) {
+    throw new Error(`Token request failed for audience ${audience}: ${token.error_description ?? token.error ?? response.statusText}`)
+  }
+  return token.access_token
+}
+
+async function postActivity (activity: object, token?: string): Promise<Response> {
+  return await fetch(humanEndpoint, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...(token ? { authorization: ['Bear', 'er ', token].join('') } : {})
+    },
+    body: JSON.stringify(activity)
+  })
+}
+
+function assertStatus (response: Response, expected: number, scenario: string): void {
+  if (response.status !== expected) {
+    throw new Error(`Expected ${expected} for ${scenario}, received ${response.status}`)
+  }
+  console.log(`Auth check passed: ${scenario} returned ${expected}.`)
+}
+
+async function waitForWiseCat (): Promise<void> {
+  const deadline = Date.now() + 30_000
+  while (Date.now() < deadline) {
+    if (captured.some((activity) => activity.text?.startsWith('Wise Cat:'))) {
+      return
+    }
+    await new Promise(resolve => setTimeout(resolve, 250))
+  }
+  throw new Error(`Timed out waiting for the Wise Cat response. Captured: ${JSON.stringify(captured)}`)
+}
+
+function requireEnv (name: string): string {
+  const value = process.env[name]?.trim()
+  if (!value) {
+    throw new Error(`Missing required environment variable ${name}`)
+  }
+  return value
+}

--- a/test-agents/a2a-agent/src/wiseCatAgent.ts
+++ b/test-agents/a2a-agent/src/wiseCatAgent.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ActivityHandler, TurnContext } from '@microsoft/agents-hosting'
+import { startServer } from '@microsoft/agents-hosting-express'
+
+class WiseCatAgent extends ActivityHandler {
+  constructor () {
+    super()
+
+    this.onMessage(async (context, next) => {
+      await context.sendActivity(buildCatReply(context))
+      await next()
+    })
+  }
+}
+
+const buildCatReply = (context: TurnContext): string => {
+  const question = context.activity.text?.trim() || 'the mysteries of the empty food bowl'
+  return `Wise Cat: Regarding "${question}", I advise patience, a warm patch of sunlight, and opening the treats immediately.`
+}
+
+await startServer(new WiseCatAgent(), {
+  port: Number(process.env.PORT ?? 3979)
+})

--- a/test-agents/a2a-agent/src/wiseCatAgent.ts
+++ b/test-agents/a2a-agent/src/wiseCatAgent.ts
@@ -23,5 +23,9 @@ const buildCatReply = (context: TurnContext): string => {
 }
 
 await startServer(new WiseCatAgent(), {
-  port: Number(process.env.PORT ?? 3979)
+  port: Number(process.env.PORT ?? 3979),
+  rateLimitOptions: {
+    windowMs: 15 * 60 * 1000,
+    max: 100
+  }
 })

--- a/test-agents/a2a-agent/tsconfig.json
+++ b/test-agents/a2a-agent/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/test-agents/root-agent/src/index.ts
+++ b/test-agents/root-agent/src/index.ts
@@ -3,7 +3,7 @@
 
 import express, { Response } from 'express'
 import rateLimit from 'express-rate-limit'
-import { Request, CloudAdapter, authorizeJWT, AuthConfiguration, loadAuthConfigFromEnv, configureResponseController, UserState, ConversationState } from '@microsoft/agents-hosting'
+import { Request, CloudAdapter, AuthConfiguration, loadAuthConfigFromEnv, configureResponseController, UserState, ConversationState } from '@microsoft/agents-hosting'
 import { version as sdkVersion } from '@microsoft/agents-hosting/package.json'
 import { RootHandlerWithBlobStorageMemory } from './agent'
 import { BlobsStorage } from '@microsoft/agents-hosting-storage-blob'
@@ -16,6 +16,7 @@ const conversationState = new ConversationState(blobStorage)
 const userState = new UserState(blobStorage)
 
 const adapter = new CloudAdapter(authConfig)
+const authorizeRequest = adapter.authorizeRequest.bind(adapter)
 
 const conversationDataAccessor = conversationState.createProperty<ConversationData>('conversationData')
 const userProfileAccessor = userState.createProperty<UserProfile>('userProfile')
@@ -30,11 +31,12 @@ const messagesRateLimiter = rateLimit({
   max: 100
 })
 
-app.post('/api/messages', messagesRateLimiter, authorizeJWT(authConfig), async (req: Request, res: Response) => {
+app.post('/api/messages', messagesRateLimiter, authorizeRequest, async (req: Request, res: Response) => {
   await adapter.process(req, res, async (context) => await myAgent.run(context))
 })
 
-app.use('/api/agentresponse', messagesRateLimiter, authorizeJWT(authConfig))
+app.use('/api/agentresponse', messagesRateLimiter)
+// The response controller applies the same adapter-owned authorization internally.
 configureResponseController(app, adapter, myAgent, conversationState)
 
 const port = process.env.PORT || 3978

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -69,6 +69,9 @@
       },
       {
         "path": "test-agents/root-agent"
+      },
+      {
+        "path": "test-agents/a2a-agent"
       }
     ]
   }


### PR DESCRIPTION
…communication

- Implemented JWT authorization in CloudAdapter for incoming requests.
- Added authorizeRequest method to CloudAdapter for handling JWT validation.
- Created AgentClient to facilitate communication between agents.
- Developed a smoke test for agent-to-agent interaction with authentication checks.
- Introduced new test agents: "I'll Ask My Cat" and "Wise Cat" for demonstration.
- Configured environment variables for agent settings and secrets.
- Updated tests to cover new authorization logic and agent interactions.