### PR TITLE
Add cooldown period for npm dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
    directory: "/"
    schedule:
      interval: monthly
+   cooldown:
+     default-days: 7
  - package-ecosystem: "github-actions"
    directory: "/"
    groups:


### PR DESCRIPTION
7 day cooldown ensures that packages are at least 7 days old before recommending them.