### PR TITLE
update documentation and add NOTICE file, package fixes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,11 +1,11 @@
 # Copilot instructions for microsoft/Agents-for-js
 
-The **Microsoft 365 Agents SDK for JavaScript/TypeScript** (successor to BotFramework SDK v4) — a framework for building agents across M365, Teams, Copilot Studio, and Webchat. It is an **npm-workspaces monorepo** (`packages/*` and `test-agents/*`) using **ES modules** (`"type": "module"`, `module: node16`) and TypeScript project references. Requires **Node.js 20+** (CI runs Node 24, which enables `--env-file`).
+The **Microsoft 365 Agents SDK for JavaScript/TypeScript** (successor to BotFramework SDK v4) — a framework for building agents across M365, Teams, Copilot Studio, and Webchat. It is an **npm-workspaces monorepo** (`packages/*` and `test-agents/*`) using **ES modules** (`"type": "module"`, `module: node16`) and TypeScript project references. Requires **Node.js 20+** (CI runs Node 24; `--env-file` requires Node 20.6+).
 
 ## Commands
 
 ```bash
-npm run build            # tsc --build via tsconfig.build.json (project references)
+npm run build            # TypeScript 7 native build via scripts/tsc7.mjs and tsconfig.build.json
 npm run build:clean      # wipe dist/ then rebuild
 npm test                 # all tests (node:test runner + tsx, emits test-report.xml)
 npm run lint             # eslint (neostandard config)
@@ -26,7 +26,7 @@ Run `npm run repo:doctor` after structural, package, documentation, build-refere
 
 Do not add npm `pre*` / `post*` lifecycle wrappers or install-time hooks (`preinstall`, `install`, `postinstall`, `prepare`). `npm --ignore-scripts` skips those hooks; make required script dependencies explicit in the invoked command.
 
-CI (`.github/workflows/ci.yml`) runs, in order: `repo:doctor` → `lint` → `lint:deps:ci` → `build` → `test` → `build:samples`. Match this before assuming work is done.
+CI (`.github/workflows/ci.yml`) runs, in order: `repo:doctor` → `lint` → `lint:deps:ci` → `build` → `test` → `compat` → `build:samples`. Match this before assuming work is done.
 
 ## Architecture (the big picture)
 
@@ -49,7 +49,7 @@ Core request flow: `CloudAdapter.process()` authenticates an incoming HTTP reque
   throw ExceptionHelper.generateException(Error, Errors.SomeKey, innerErr?, { tmplKey: value })
   ```
   The returned `AgentError` exposes `.code`, `.helpLink`, `.innerException` — the description is only embedded in the formatted `.message`. New errors continue the package's numeric sequence.
-- **Public API is contract-checked.** api-extractor compares each package's `dist/src/index.d.ts` against `compat/baseline/<pkg>.api.md`. After an intentional public-API change, regenerate the baseline: `npm run compat <pkg> -- --local` (e.g. `npm run compat agents-hosting -- --local`), then commit the updated `.api.md`. Prefer backward-compatible changes (additive exports, parameter widening, overloads, structural shims) over breaking ones. Note: per-package compat is reliable; `npm run compat` (all packages) currently errors on `agents-telemetry` because it has no `dist/src/index.d.ts`.
+- **Public API is contract-checked.** api-extractor compares each package's generated declarations against `compat/baseline/<pkg>.api.md`. After an intentional public-API change, regenerate the baseline: `npm run compat <pkg> -- --local` (e.g. `npm run compat agents-hosting -- --local`), then commit the updated `.api.md`. Prefer backward-compatible changes (additive exports, parameter widening, overloads, structural shims) over breaking ones.
 - **Tests** live in each package's `test/` dir as `*.test.ts`, use `node:test` (`describe`/`it`) + `node:assert`. `tsx` transpiles without type-checking — type-level assertions only count if compiled by `npm run build` (i.e. placed in `src/`, not `test/`).
 - **ESM**: built output uses explicit file extensions; `engines.node >= 20`. Sample/test-agents load config via Node's `--env-file .env`.
 - **Logging**: uses the `debug` library. `debug('agents:<subsystem>')` returns a `Logger` with `.info()/.warn()/.error()/.debug()` (it is not directly callable). Enable with the `DEBUG` env var (e.g. `DEBUG=agents:cloud-adapter:*`); namespaces are documented in `README.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,11 +17,14 @@ The repository is a **monorepo** using npm workspaces with multiple interconnect
 - **agents-hosting-express**: Express.js integration for hosting agents.
 - **agents-hosting-fastify**: Fastify integration for hosting agents.
 - **agents-hosting-dialogs**: Dialog system for building conversational flows. Replaces `botbuilder-dialogs`.
+- **agents-hosting-directline-namedpipes**: Direct Line transport over named pipes.
 - **agents-hosting-extensions-msteams**: Teams-specific features (TaskModules, Messaging Extensions).
+- **agents-hosting-extensions-slack**: Slack-specific integration and extensions.
 - **agents-hosting-extensions-teams**: Deprecated legacy Teams extension retained for backward compatibility.
 - **agents-hosting-storage-blob**: Azure Blob Storage adapter. Replaces `botbuilder-azure`.
 - **agents-hosting-storage-cosmos**: CosmosDB storage adapter. Replaces `botbuilder-azure`.
 - **agents-copilotstudio-client**: Direct-to-Engine client for interacting with Copilot Studio agents.
+- **agents-telemetry**: Shared telemetry instrumentation for Microsoft 365 Agents SDK packages.
 
 ### Test Agents (in `test-agents/`)
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The nightly build contains the code from our `main` branch and may contain featu
 
 The packages require Node.js 20 or greater, and can be used from JavaScript using CommonJS or ES6 modules, or from TypeScript.
 
-> Note: We are using node 24 to be able to initialize the process from a `.env` file without adding the dependency to `dotenv` by using the [`--env-file` flag](https://nodejs.org/en/learn/command-line/how-to-read-environment-variables-from-nodejs). Previous node versions should set the env vars explicitly before running.
+> Note: Development and CI use Node.js 24. The [`--env-file` flag](https://nodejs.org/en/learn/command-line/how-to-read-environment-variables-from-nodejs) is available in Node.js 20.6 and later; Node.js 20.0–20.5 users should set environment variables explicitly before running.
 
 ### Debugging
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -836,9 +836,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -924,9 +924,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3242,9 +3242,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4123,9 +4123,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4223,9 +4223,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6460,9 +6460,9 @@
       "license": "MIT"
     },
     "node_modules/npm-run-all/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/agents-hosting-dialogs/NOTICE
+++ b/packages/agents-hosting-dialogs/NOTICE
@@ -1,0 +1,59 @@
+NOTICES AND INFORMATION
+Do Not Translate or Localize
+
+This software incorporates material from third parties. Microsoft makes certain
+open source code available at https://3rdpartysource.microsoft.com, or you may
+send a check or money order for US $5.00, including the product name, the open
+source component name, and version number, to:
+
+Source Code Compliance Team
+Microsoft Corporation
+One Microsoft Way
+Redmond, WA 98052
+USA
+
+Notwithstanding any other terms, you may reverse engineer this software to the
+extent required to debug changes to any libraries licensed under the GNU Lesser
+General Public License.
+
+Component: cldr-data
+
+Open Source License/Copyright Notice:
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 2004-2026 Unicode, Inc.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the "Data Files") or
+software and any associated documentation (the "Software") to deal in the
+Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.

--- a/packages/agents-hosting-dialogs/package.json
+++ b/packages/agents-hosting-dialogs/package.json
@@ -30,6 +30,7 @@
   "license": "MIT",
   "files": [
     "README.md",
+    "NOTICE",
     "dist/src",
     "dist/vendor",
     "src",

--- a/packages/agents-hosting/test/cases/authentication/msteams.md
+++ b/packages/agents-hosting/test/cases/authentication/msteams.md
@@ -24,9 +24,6 @@ This document presents a comprehensive suite of test cases for authentication ha
 
 ## Test Cases
 
-> [!NOTE]
-> These test cases were created using the [autoAuth](/samples/auth/autoAuth.ts) sample.
-
 ### 1. Basic Login Flow
 
 **Description:**

--- a/packages/agents-hosting/test/cases/authentication/webchat.md
+++ b/packages/agents-hosting/test/cases/authentication/webchat.md
@@ -24,9 +24,6 @@ This document presents a comprehensive suite of test cases for authentication ha
 
 ## Test Cases
 
-> [!NOTE]
-> These test cases were created using the [autoAuth](/samples/auth/autoAuth.ts) sample.
-
 ### 1. Basic Login Flow
 
 **Description:**


### PR DESCRIPTION
This pull request updates documentation and package metadata across the repository to clarify build requirements, CI workflow, and package structure. It also adds missing legal notices for third-party components and updates the package file list.

Documentation and build process clarifications:

* Updated `.github/copilot-instructions.md` and `README.md` to clarify Node.js version requirements and the use of the `--env-file` flag, specifying that Node.js 20.6+ is required for this feature and that development/CI use Node.js 24. Also clarified the build command now uses TypeScript 7 and updated the CI workflow to include the `compat` step. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L3-R8) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L29-R29) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R52)
* Improved the explanation of public API compatibility checks and removed outdated details about specific package errors.

Repository/package structure updates:

* Added new packages to the repository overview in `CLAUDE.md`, including `agents-hosting-directline-namedpipes`, `agents-hosting-extensions-slack`, and `agents-telemetry`.

Legal/compliance updates:

* Added a `NOTICE` file to `packages/agents-hosting-dialogs` containing the required open source license notice for `cldr-data`, and included this file in the package's published files in `package.json`. [[1]](diffhunk://#diff-dfe86932a20e9ac8cdbc2ed212ae52e933b86fb84ec75f7c436a4dbd752fd4e3R1-R59) [[2]](diffhunk://#diff-2bba3e8727131359c0c11bc021ba19f292618b83faeab6efab78a08faea8a0dcR33)

Documentation cleanup:

* Removed redundant or outdated note blocks from test case documentation for authentication flows in `packages/agents-hosting/test/cases/authentication/msteams.md` and `webchat.md`. [[1]](diffhunk://#diff-c029ecd598a81d8449a910c04b9776473186f5ff50628cf3df0046a6fd559a33L27-L29) [[2]](diffhunk://#diff-2a3126f448ed7b689924c6912686e56279236542a8e02d5d5907631266e1aee5L27-L29)