### PR TITLE
combined dependabot fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "test-agents/*"
       ],
       "devDependencies": {
-        "@microsoft/api-extractor": "7.58.7",
+        "@microsoft/api-extractor": "7.59.0",
         "@microsoft/m365agentsplayground": "0.2.23",
         "@microsoft/microsoft-graph-client": "3.0.7",
         "@microsoft/microsoft-graph-types": "2.43.1",
@@ -30,8 +30,8 @@
         "nerdbank-gitversioning": "3.10.91",
         "npm-run-all": "4.1.5",
         "sinon": "22.1.0",
-        "tsx": "4.22.4",
-        "typedoc": "0.28.18",
+        "tsx": "4.23.12",
+        "typedoc": "0.28.20",
         "typescript": "npm:@typescript/typescript6@6.0.2",
         "yaml": "2.8.3"
       },
@@ -246,6 +246,26 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.13.0",
+      "integrity": "sha1-YuQkxrIeFD6O9DdKZNv4dy3+Ggc=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.6.0",
+      "integrity": "sha1-jL/v8CG20vPQZKOvuCJirZhehDQ=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.13.0",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@azure/storage-blob": {
@@ -1205,18 +1225,18 @@
       "link": true
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.58.7",
-      "integrity": "sha512-yK6OycD46gIzLRpj6ueVUWPk1ACSpkN1LBo05gY1qPTylbWyUCanXfH7+VgkI5LJrJoRSQR5F04XuCffCXLOBw==",
+      "version": "7.59.0",
+      "integrity": "sha1-o0UGvOpvK9fAnA9sg1iQcCkfFjQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.33.8",
+        "@microsoft/api-extractor-model": "7.33.11",
         "@microsoft/tsdoc": "~0.16.0",
         "@microsoft/tsdoc-config": "~0.18.1",
-        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/node-core-library": "5.24.0",
         "@rushstack/rig-package": "0.7.3",
-        "@rushstack/terminal": "0.24.0",
-        "@rushstack/ts-command-line": "5.3.9",
+        "@rushstack/terminal": "0.24.3",
+        "@rushstack/ts-command-line": "5.3.13",
         "diff": "~8.0.2",
         "minimatch": "10.2.3",
         "resolve": "~1.22.1",
@@ -1226,17 +1246,23 @@
       },
       "bin": {
         "api-extractor": "bin/api-extractor"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.33.8",
-      "integrity": "sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==",
+      "version": "7.33.11",
+      "integrity": "sha1-vQF2oH9qqgLaEMEigzR+962JCig=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "~0.16.0",
         "@microsoft/tsdoc-config": "~0.18.1",
-        "@rushstack/node-core-library": "5.23.1"
+        "@rushstack/node-core-library": "5.24.0"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/typescript": {
@@ -1415,13 +1441,13 @@
     },
     "node_modules/@microsoft/tsdoc": {
       "version": "0.16.0",
-      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "integrity": "sha1-IkkJBjPgQGMXaGOgUMjwgI0rbSs=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@microsoft/tsdoc-config": {
       "version": "0.18.1",
-      "integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
+      "integrity": "sha1-fFYLzmKrtfloHk0jG5rDVVO36Gs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1768,11 +1794,11 @@
       "license": "MIT"
     },
     "node_modules/@rushstack/node-core-library": {
-      "version": "5.23.1",
-      "integrity": "sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==",
+      "version": "5.24.0",
+      "integrity": "sha1-A2xc/Dth7W9dfwK/oKTGmYyIt1w=",
       "license": "MIT",
       "dependencies": {
-        "ajv": "~8.18.0",
+        "ajv": "~8.20.0",
         "ajv-draft-04": "~1.0.0",
         "ajv-formats": "~3.0.1",
         "fs-extra": "~11.3.0",
@@ -1781,6 +1807,9 @@
         "resolve": "~1.22.1",
         "semver": "~7.7.4"
       },
+      "engines": {
+        "node": ">=20.9.0"
+      },
       "peerDependencies": {
         "@types/node": "*"
       },
@@ -1788,6 +1817,21 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/ajv": {
+      "version": "8.20.0",
+      "integrity": "sha1-MEs2Nq3Yi6fZNnYN1Q7OAG3qlfk=",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@rushstack/problem-matcher": {
@@ -1814,13 +1858,16 @@
       }
     },
     "node_modules/@rushstack/terminal": {
-      "version": "0.24.0",
-      "integrity": "sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==",
+      "version": "0.24.3",
+      "integrity": "sha1-AI41dI2JJ4nKrbZ7AgHsIkM99rE=",
       "license": "MIT",
       "dependencies": {
-        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/node-core-library": "5.24.0",
         "@rushstack/problem-matcher": "0.2.1",
         "supports-color": "~8.1.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "peerDependencies": {
         "@types/node": "*"
@@ -1832,15 +1879,18 @@
       }
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "5.3.9",
-      "integrity": "sha512-GIHqU+sRGQ3LGWAZu1O+9Yh++qwtyNIIGuNbcWHJjBTm2qRez0cwINUHZ+pQLR8UuzZDcMajrDaNbUYoaL/XtQ==",
+      "version": "5.3.13",
+      "integrity": "sha1-n+9jCYIVu2SQ7eW95TRd9dPMgDg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rushstack/terminal": "0.24.0",
+        "@rushstack/terminal": "0.24.3",
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
         "string-argv": "~0.3.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
@@ -1954,7 +2004,7 @@
     },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
-      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+      "integrity": "sha1-qB/YYG1IH4c6OADG665PHXaKVqk=",
       "dev": true,
       "license": "MIT"
     },
@@ -2821,7 +2871,7 @@
     },
     "node_modules/argparse": {
       "version": "1.0.10",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3540,6 +3590,7 @@
     },
     "node_modules/entities": {
       "version": "4.5.0",
+      "integrity": "sha1-XSaOpecRPsdMTQM7eepaNaSI+0g=",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -4209,10 +4260,11 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "8.6.2",
+      "integrity": "sha1-Gmx/tsX1qDiDwU8dGY/N/2AIfF0=",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {
@@ -4349,38 +4401,6 @@
         "fxparser": "src/cli/cli.js"
       }
     },
-    "node_modules/fastify": {
-      "version": "5.8.5",
-      "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/ajv-compiler": "^4.0.5",
-        "@fastify/error": "^4.0.0",
-        "@fastify/fast-json-stringify-compiler": "^5.0.0",
-        "@fastify/proxy-addr": "^5.0.0",
-        "abstract-logging": "^2.0.1",
-        "avvio": "^9.0.0",
-        "fast-json-stringify": "^6.0.0",
-        "find-my-way": "^9.0.0",
-        "light-my-request": "^6.0.0",
-        "pino": "^9.14.0 || ^10.1.0",
-        "process-warning": "^5.0.0",
-        "rfdc": "^1.3.1",
-        "secure-json-parse": "^4.0.0",
-        "semver": "^7.6.0",
-        "toad-cache": "^3.7.0"
-      }
-    },
     "node_modules/fastify-empty-agent": {
       "resolved": "test-agents/fastify-empty-agent",
       "link": true
@@ -4388,21 +4408,6 @@
     "node_modules/fastify-plugin": {
       "version": "5.0.1",
       "integrity": "sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==",
-      "license": "MIT"
-    },
-    "node_modules/fastify/node_modules/process-warning": {
-      "version": "5.0.0",
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -5732,7 +5737,7 @@
     },
     "node_modules/linkify-it": {
       "version": "5.0.2",
-      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "integrity": "sha1-074KaTrz2p3ziD8eNGoOl0YajBk=",
       "dev": true,
       "funding": [
         {
@@ -5854,8 +5859,8 @@
       "license": "MIT"
     },
     "node_modules/markdown-it": {
-      "version": "14.2.0",
-      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "version": "14.3.0",
+      "integrity": "sha1-hUL6VQbjUw9+KwjcOIVjATXFYg4=",
       "dev": true,
       "funding": [
         {
@@ -5870,8 +5875,8 @@
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -5882,6 +5887,7 @@
     },
     "node_modules/markdown-it/node_modules/argparse": {
       "version": "2.0.1",
+      "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
       "dev": true,
       "license": "Python-2.0"
     },
@@ -5893,7 +5899,8 @@
       }
     },
     "node_modules/mdurl": {
-      "version": "2.0.0",
+      "version": "2.1.0",
+      "integrity": "sha1-1xHT97zn8ixIfJG+eFRfNW+pZXM=",
       "dev": true,
       "license": "MIT"
     },
@@ -6862,6 +6869,7 @@
     },
     "node_modules/punycode.js": {
       "version": "2.3.1",
+      "integrity": "sha1-a1PlatdViCNOefSv+pCXLH3Yzbc=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7526,7 +7534,7 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -7555,7 +7563,7 @@
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
-      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "integrity": "sha1-K20O8ktlYnTZV9VOCku/YVPcArY=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7823,8 +7831,8 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.22.4",
-      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "version": "4.23.12",
+      "integrity": "sha1-OkkZWRzZueAAEbdeWWyKuNsjwJw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7960,16 +7968,16 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.28.18",
-      "integrity": "sha512-NTWTUOFRQ9+SGKKTuWKUioUkjxNwtS3JDRPVKZAXGHZy2wCA8bdv2iJiyeePn0xkmK+TCCqZFT0X7+2+FLjngA==",
+      "version": "0.28.20",
+      "integrity": "sha1-I8nIQVh8UotWz5wNAXynF3RbsNk=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
-        "markdown-it": "^14.1.1",
-        "minimatch": "^10.2.4",
-        "yaml": "^2.8.2"
+        "markdown-it": "^14.3.0",
+        "minimatch": "^10.2.5",
+        "yaml": "^2.9.0"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -7995,6 +8003,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typedoc/node_modules/yaml": {
+      "version": "2.9.0",
+      "integrity": "sha1-eCdK/ZNZih391hMN9qVm3vy/mqQ=",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/typescript": {
@@ -8035,7 +8058,7 @@
     },
     "node_modules/uc.micro": {
       "version": "2.1.0",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "integrity": "sha1-+NP30OxMPeo1p+PI76TLi0XJ5+4=",
       "dev": true,
       "license": "MIT"
     },
@@ -8331,7 +8354,7 @@
       "license": "MIT",
       "dependencies": {
         "@azure/core-auth": "1.10.1",
-        "@azure/msal-node": "5.1.5",
+        "@azure/msal-node": "5.6.0",
         "@microsoft/agents-activity": "file:../agents-activity",
         "@microsoft/agents-telemetry": "file:../agents-telemetry",
         "jsonwebtoken": "9.0.3",
@@ -8384,7 +8407,7 @@
         "@microsoft/agents-hosting": "file:../agents-hosting",
         "@microsoft/agents-telemetry": "file:../agents-telemetry",
         "express": "5.2.1",
-        "express-rate-limit": "8.5.2"
+        "express-rate-limit": "8.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -8454,6 +8477,55 @@
         "fastify": ">=5.0.0"
       }
     },
+    "packages/agents-hosting-fastify/node_modules/fastify": {
+      "version": "5.8.5",
+      "integrity": "sha1-xFIiQpXgylULzQ78P30+kOnBGVU=",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.5",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^6.0.0",
+        "find-my-way": "^9.0.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^9.14.0 || ^10.1.0",
+        "process-warning": "^5.0.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "packages/agents-hosting-fastify/node_modules/process-warning": {
+      "version": "5.1.0",
+      "integrity": "sha1-DqCUsYthD1lCQ+/FheIPLb7lVdw=",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "packages/agents-hosting-storage-blob": {
       "name": "@microsoft/agents-hosting-storage-blob",
       "version": "0.1.0",
@@ -8482,26 +8554,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "packages/agents-hosting/node_modules/@azure/msal-common": {
-      "version": "16.5.2",
-      "integrity": "sha512-GkDEL6TYo3HgT3UuqakdgE9PZfc1hMki6+Hwgy1uddb/EauvAKfu85vVhuofRSo22D1xTnWt8Ucwfg4vSCVwvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "packages/agents-hosting/node_modules/@azure/msal-node": {
-      "version": "5.1.5",
-      "integrity": "sha512-ObTeMoNPmq19X3z40et9Xvs4ZoWVeJg43PZMRLG5iwVL+2nCtAerG3YTDItqPp1CfXNwmCXBbg8jn1DOx65c3g==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/msal-common": "16.5.2",
-        "jsonwebtoken": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "packages/agents-telemetry": {
@@ -8576,37 +8628,17 @@
         "@microsoft/agents-hosting-storage-blob": "file:../../packages/agents-hosting-storage-blob",
         "@microsoft/agents-hosting-storage-cosmos": "file:../../packages/agents-hosting-storage-cosmos",
         "express": "5.2.1",
-        "express-rate-limit": "8.5.2"
+        "express-rate-limit": "8.6.2"
       }
     },
     "test-agents/copilotstudio-console": {
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-node": "5.1.5",
+        "@azure/msal-node": "5.6.0",
         "@microsoft/agents-activity": "file:../../packages/agents-activity",
         "@microsoft/agents-copilotstudio-client": "file:../../packages/agents-copilotstudio-client",
         "open": "11.0.0"
-      }
-    },
-    "test-agents/copilotstudio-console/node_modules/@azure/msal-common": {
-      "version": "16.5.2",
-      "integrity": "sha512-GkDEL6TYo3HgT3UuqakdgE9PZfc1hMki6+Hwgy1uddb/EauvAKfu85vVhuofRSo22D1xTnWt8Ucwfg4vSCVwvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "test-agents/copilotstudio-console/node_modules/@azure/msal-node": {
-      "version": "5.1.5",
-      "integrity": "sha512-ObTeMoNPmq19X3z40et9Xvs4ZoWVeJg43PZMRLG5iwVL+2nCtAerG3YTDItqPp1CfXNwmCXBbg8jn1DOx65c3g==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/msal-common": "16.5.2",
-        "jsonwebtoken": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "test-agents/custom-dialogs": {
@@ -8617,7 +8649,7 @@
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/agents-hosting-dialogs": "file:../../packages/agents-hosting-dialogs",
         "express": "5.2.1",
-        "express-rate-limit": "8.5.2"
+        "express-rate-limit": "8.6.2"
       }
     },
     "test-agents/delegated-agent-callback": {
@@ -8627,7 +8659,7 @@
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/agents-hosting-express": "file:../../packages/agents-hosting-express",
         "express": "5.2.1",
-        "express-rate-limit": "8.5.2"
+        "express-rate-limit": "8.6.2"
       }
     },
     "test-agents/empty-agent": {
@@ -8647,6 +8679,53 @@
         "fastify": "5.8.5"
       }
     },
+    "test-agents/fastify-empty-agent/node_modules/fastify": {
+      "version": "5.8.5",
+      "integrity": "sha1-xFIiQpXgylULzQ78P30+kOnBGVU=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.5",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^6.0.0",
+        "find-my-way": "^9.0.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^9.14.0 || ^10.1.0",
+        "process-warning": "^5.0.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "test-agents/fastify-empty-agent/node_modules/process-warning": {
+      "version": "5.1.0",
+      "integrity": "sha1-DqCUsYthD1lCQ+/FheIPLb7lVdw=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "test-agents/multi-turn-prompt": {
       "name": "multiturn-prompts-agent",
       "version": "1.0.0",
@@ -8656,7 +8735,7 @@
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/agents-hosting-dialogs": "file:../../packages/agents-hosting-dialogs",
         "express": "5.2.1",
-        "express-rate-limit": "8.5.2"
+        "express-rate-limit": "8.6.2"
       }
     },
     "test-agents/named-pipe-agent": {
@@ -8684,7 +8763,7 @@
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/agents-hosting-storage-blob": "file:../../packages/agents-hosting-storage-blob",
         "express": "5.2.1",
-        "express-rate-limit": "8.5.2"
+        "express-rate-limit": "8.6.2"
       }
     },
     "test-agents/sidecar-auth": {
@@ -8713,7 +8792,7 @@
         "@microsoft/agents-hosting-storage-blob": "file:../../packages/agents-hosting-storage-blob",
         "@microsoft/agents-hosting-storage-cosmos": "file:../../packages/agents-hosting-storage-cosmos",
         "express": "5.2.1",
-        "express-rate-limit": "8.5.2"
+        "express-rate-limit": "8.6.2"
       }
     },
     "test-agents/web-chat": {
@@ -8724,7 +8803,7 @@
         "@microsoft/agents-activity": "file:../../packages/agents-activity",
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "express": "5.2.1",
-        "express-rate-limit": "8.5.2"
+        "express-rate-limit": "8.6.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test-agents/*"
   ],
   "devDependencies": {
-    "@microsoft/api-extractor": "7.58.7",
+    "@microsoft/api-extractor": "7.59.0",
     "@microsoft/m365agentsplayground": "0.2.23",
     "@microsoft/microsoft-graph-client": "3.0.7",
     "@microsoft/microsoft-graph-types": "2.43.1",
@@ -65,8 +65,8 @@
     "nerdbank-gitversioning": "3.10.91",
     "npm-run-all": "4.1.5",
     "sinon": "22.1.0",
-    "tsx": "4.22.4",
-    "typedoc": "0.28.18",
+    "tsx": "4.23.12",
+    "typedoc": "0.28.20",
     "typescript": "npm:@typescript/typescript6@6.0.2",
     "yaml": "2.8.3"
   },

--- a/packages/agents-hosting-express/package.json
+++ b/packages/agents-hosting-express/package.json
@@ -22,7 +22,7 @@
     "@microsoft/agents-hosting": "file:../agents-hosting",
     "@microsoft/agents-telemetry": "file:../agents-telemetry",
     "express": "5.2.1",
-    "express-rate-limit": "8.5.2"
+    "express-rate-limit": "8.6.2"
   },
   "license": "MIT",
   "files": [

--- a/packages/agents-hosting/package.json
+++ b/packages/agents-hosting/package.json
@@ -20,7 +20,7 @@
   "types": "dist/src/index.d.ts",
   "dependencies": {
     "@azure/core-auth": "1.10.1",
-    "@azure/msal-node": "5.1.5",
+    "@azure/msal-node": "5.6.0",
     "@microsoft/agents-activity": "file:../agents-activity",
     "@microsoft/agents-telemetry": "file:../agents-telemetry",
     "jsonwebtoken": "9.0.3",

--- a/test-agents/application-style/package.json
+++ b/test-agents/application-style/package.json
@@ -20,6 +20,6 @@
         "@microsoft/agents-hosting-storage-cosmos": "file:../../packages/agents-hosting-storage-cosmos",
         "@microsoft/agents-activity": "file:../../packages/agents-activity",
         "express": "5.2.1",
-        "express-rate-limit": "8.5.2"
+        "express-rate-limit": "8.6.2"
     }
 }

--- a/test-agents/copilotstudio-console/package.json
+++ b/test-agents/copilotstudio-console/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@microsoft/agents-activity": "file:../../packages/agents-activity",
     "@microsoft/agents-copilotstudio-client": "file:../../packages/agents-copilotstudio-client",
-    "@azure/msal-node": "5.1.5",
+    "@azure/msal-node": "5.6.0",
     "open": "11.0.0"
   }
 }

--- a/test-agents/custom-dialogs/package.json
+++ b/test-agents/custom-dialogs/package.json
@@ -17,6 +17,6 @@
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/agents-activity": "file:../../packages/agents-activity",
         "express": "5.2.1",
-        "express-rate-limit": "8.5.2"
+        "express-rate-limit": "8.6.2"
     }
 }

--- a/test-agents/delegated-agent-callback/package.json
+++ b/test-agents/delegated-agent-callback/package.json
@@ -17,6 +17,6 @@
     "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
     "@microsoft/agents-hosting-express": "file:../../packages/agents-hosting-express",
     "express": "5.2.1",
-    "express-rate-limit": "8.5.2"
+    "express-rate-limit": "8.6.2"
   }
 }

--- a/test-agents/multi-turn-prompt/package.json
+++ b/test-agents/multi-turn-prompt/package.json
@@ -16,6 +16,6 @@
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/agents-activity": "file:../../packages/agents-activity",
         "express": "5.2.1",
-        "express-rate-limit": "8.5.2"
+        "express-rate-limit": "8.6.2"
     }
 }

--- a/test-agents/root-agent/package.json
+++ b/test-agents/root-agent/package.json
@@ -16,6 +16,6 @@
     "@microsoft/agents-activity": "file:../../packages/agents-activity",
     "@microsoft/agents-hosting-storage-blob": "file:../../packages/agents-hosting-storage-blob",
     "express": "5.2.1",
-    "express-rate-limit": "8.5.2"
+    "express-rate-limit": "8.6.2"
   }
 }

--- a/test-agents/state-agent/package.json
+++ b/test-agents/state-agent/package.json
@@ -19,6 +19,6 @@
     "@microsoft/agents-hosting-storage-blob": "file:../../packages/agents-hosting-storage-blob",
     "@microsoft/agents-hosting-storage-cosmos": "file:../../packages/agents-hosting-storage-cosmos",
     "express": "5.2.1",
-    "express-rate-limit": "8.5.2"
+    "express-rate-limit": "8.6.2"
   }
 }

--- a/test-agents/web-chat/package.json
+++ b/test-agents/web-chat/package.json
@@ -15,6 +15,6 @@
     "@microsoft/agents-activity": "file:../../packages/agents-activity",
     "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
     "express": "5.2.1",
-    "express-rate-limit": "8.5.2"
+    "express-rate-limit": "8.6.2"
   }
 }


### PR DESCRIPTION
## Summary

Combines the dependency updates from the following Dependabot PRs into a single change:

- #1277 — `@microsoft/api-extractor` `7.58.7` → `7.59.0`
- #1276 — `typedoc` `0.28.18` → `0.28.20`
- #1275 — `@azure/msal-node` `5.1.5` → `5.6.0`
- #1274 — `express-rate-limit` `8.5.2` → `8.6.2`
- #1273 — `tsx` `4.22.4` → `4.23.12`

The package manifests and `package-lock.json` were regenerated as one coherent dependency graph. PRs #1280 (`fastify`) and #1279 (`fast-uri`) are intentionally excluded.

## Notable changes

- **MSAL Node:** Adds Agent Identity `fmi_path` and `user_fic` support, Azure Arc managed-identity improvements, safer credential cache keys, and additional authentication hardening.
- **express-rate-limit:** Improves IPv4-mapped IPv6 key handling, limiter counter correctness, validation behavior, and diagnostics.
- **API Extractor:** Reports unresolved relative inline imports instead of silently emitting unusable declaration paths, with declaration-processing performance improvements.
- **TypeDoc:** Improves Windows line-ending handling, rendering performance, heading links, and documentation ordering.
- **tsx:** Improves ESM and module resolution, Node test source locations, loader behavior, and startup performance.

No SDK source changes were required for these updates.

## Validation

- [x] Clean `npm ci`
- [x] `npm run repo:doctor`
- [x] `npm run lint`
- [x] `npm run lint:deps:ci`
- [x] `npm run build`
- [x] `npm test`
- [x] `npm run compat`
- [x] `npm run build:samples`
- [x] `git diff --check`

## Related PRs

Closes #1277  
Closes #1276  
Closes #1275  
Closes #1274  
Closes #1273