### PR TITLE
[#1282] Deprecate span category filter in favor of custom parent sampler

### DIFF
--- a/packages/agents-telemetry/README.md
+++ b/packages/agents-telemetry/README.md
@@ -17,7 +17,7 @@ This package supports both ESM and CommonJS consumers and requires Node.js 20 or
 
 ## For Agent Developers
 
-This section covers how to enable and configure telemetry in your agent application. The SDK automatically instruments its components — you only need to wire up OpenTelemetry exporters and, optionally, tune which span categories are active.
+This section covers how to enable and configure telemetry in your agent application. The SDK automatically instruments its components — you only need to wire up OpenTelemetry exporters and, optionally, configure sampling for the spans you want to collect.
 
 ### Peer Dependencies
 
@@ -93,26 +93,59 @@ const sdk = new NodeSDK({
 sdk.start()
 ```
 
-### Disabling Span Categories
+### Filtering Spans with a Parent-Based Sampler
 
-All built-in span categories are enabled by default. To disable one or more categories without changing code, set `AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES` in your environment:
+Configure filtering in your OpenTelemetry SDK with a custom sampler. A parent-based delegate ensures that descendants of a filtered span are also excluded while preserving the sampling decision for all other traces.
 
+The following reusable sampler filters spans by their names. This example excludes automatic typing-indicator spans and their adapter and connector descendants:
+
+```ts
+import { SpanNames } from '@microsoft/agents-telemetry'
+import { NodeSDK } from '@opentelemetry/sdk-node'
+import {
+  AlwaysOnSampler,
+  ParentBasedSampler,
+  SamplingDecision,
+  type Sampler,
+} from '@opentelemetry/sdk-trace-base'
+import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-node'
+
+class SpanNameFilteringSampler implements Sampler {
+  private readonly filteredSpanNames: ReadonlySet<string>
+  private readonly parentBased = new ParentBasedSampler({
+    root: new AlwaysOnSampler(),
+  })
+
+  constructor (spanNames: Iterable<string>) {
+    this.filteredSpanNames = new Set(spanNames)
+  }
+
+  shouldSample (...args: Parameters<Sampler['shouldSample']>) {
+    return this.filteredSpanNames.has(args[2])
+      ? { decision: SamplingDecision.NOT_RECORD }
+      : this.parentBased.shouldSample(...args)
+  }
+
+  toString () {
+    return `SpanNameFilteringSampler(${[...this.filteredSpanNames].join(',')})`
+  }
+}
+
+const sdk = new NodeSDK({
+  sampler: new SpanNameFilteringSampler([
+    SpanNames.AGENTS_APP_TYPING_INDICATOR,
+  ]),
+  traceExporter: new ConsoleSpanExporter(),
+  serviceName: 'my-agent-service',
+})
+
+sdk.start()
 ```
-AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES=STORAGE,AUTHORIZATION
 
-# or
+Add any other values from `SpanNames` to the sampler's list when you need to filter additional SDK spans.
 
-AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES=STORAGE AUTHORIZATION
-```
-
-Valid category names are:
-
-- `STORAGE`
-- `AUTHENTICATION`
-- `AUTHORIZATION`
-- `DIALOGS`
-
-When a span category is disabled, instrumented code still runs normally with a noop context — no telemetry is emitted for those spans.
+> [!WARNING]
+> `AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES` is deprecated and will be removed in a future release. It remains supported temporarily for backward compatibility, but new applications should configure an OpenTelemetry sampler instead.
 
 ### Span and Metric Names
 
@@ -242,7 +275,7 @@ trace(storageReadTrace, ({ record }) => {
 - On failure, the exception is recorded on the span, status is set to `ERROR`, and the error is rethrown.
 - Non-Error thrown values are recorded with their type name and string representation.
 - Unrecognized span names throw immediately.
-- Disabled span categories run the callback with a noop context — no telemetry is emitted.
+- The deprecated disabled-span categories run the callback with a noop context — no telemetry is emitted.
 - Managed spans can start parented spans with `child(definition)` or `child(definition, callback)`.
 - Record updates recursively merge plain objects; arrays are copied and replaced.
 - The `end` hook receives `{ span, record, duration, error? }`.
@@ -285,7 +318,7 @@ When `@opentelemetry/api` is not available, the instruments are safe noops.
 - **Record tracking**: Accumulate structured data during a trace and access it in the `end` hook
 - **Managed child spans**: Start child spans from a managed trace context when a manual parent span stays open
 - **Custom actions**: Define span-scoped helper functions via the `actions` factory
-- **Category-based disabling**: Disable groups of spans via environment configuration
+- **Sampler-based filtering**: Use OpenTelemetry parent-based sampling to exclude selected spans and their descendants
 - **Noop fallback**: All instrumentation calls are safe no-ops when OpenTelemetry APIs are not installed
 
 ---

--- a/packages/agents-telemetry/src/observability/category.ts
+++ b/packages/agents-telemetry/src/observability/category.ts
@@ -23,6 +23,8 @@ const disabledSpans = (() => {
     return []
   }
 
+  logger.warn(`${AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES} is deprecated and will be removed in a future release. Configure an OpenTelemetry parent-based sampler instead.`)
+
   const envCategories = rawValue
     .split(/[\s,]+/)
     .map((category) => category.trim())
@@ -63,6 +65,8 @@ const disabledSpans = (() => {
  * Determines if a span is disabled based on its name and the `AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES` environment variable or configuration setting.
  * @param name The name of the span to check.
  * @returns A boolean indicating whether the span is disabled.
+ *
+ * @deprecated Configure an OpenTelemetry parent-based sampler to filter spans instead.
  */
 export function isSpanDisabled (name: SpanName): boolean {
   if (disabledSpans.length === 0) {

--- a/packages/agents-telemetry/src/observability/constants.ts
+++ b/packages/agents-telemetry/src/observability/constants.ts
@@ -5,11 +5,15 @@
 
 /**
  * Environment variable or configuration setting name for disabling spans by category in the Agents SDK telemetry. The value should be comma-separated or whitespace-separated list of span categories to disable. See `SpanCategories` for available categories.
+ *
+ * @deprecated Configure an OpenTelemetry parent-based sampler to filter spans instead.
  */
 export const AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = 'AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES'
 
 /**
  * Categories of spans used for telemetry in the Agents SDK. Spans can be disabled by category using the `AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES` environment variable or configuration setting.
+ *
+ * @deprecated Configure an OpenTelemetry parent-based sampler to filter spans instead.
  */
 export const SpanCategories = {
   STORAGE: ['STORAGE_'],

--- a/packages/agents-telemetry/test/observability/category.test.ts
+++ b/packages/agents-telemetry/test/observability/category.test.ts
@@ -1,0 +1,137 @@
+import assert from 'assert'
+import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { describe, it } from 'node:test'
+
+const SETTING_NAME = 'AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES'
+const DEPRECATION_WARNING = `${SETTING_NAME} is deprecated and will be removed in a future release. Configure an OpenTelemetry parent-based sampler instead.`
+const categoryModuleUrl = pathToFileURL(resolve(__dirname, '../../src/observability/category.ts')).href
+const traceModuleUrl = pathToFileURL(resolve(__dirname, '../../src/observability/trace.ts')).href
+const repoDir = resolve(__dirname, '../../../..')
+
+type CategoryProbe = {
+  storageRead: boolean
+  authorizationSignIn: boolean
+  userTokenClientGetToken: boolean
+  adapterProcess: boolean
+  storageTraceStarted: boolean
+  storageTraceCallbackRan: boolean
+}
+
+function runCategoryProbe (setting?: string): { probe: CategoryProbe, stderr: string } {
+  const env = {
+    ...process.env,
+    DEBUG: 'agents:telemetry:*',
+  }
+
+  if (setting === undefined) {
+    delete env[SETTING_NAME]
+  } else {
+    env[SETTING_NAME] = setting
+  }
+
+  const script = `
+    const categoryModule = await import(${JSON.stringify(categoryModuleUrl)})
+    const traceModule = await import(${JSON.stringify(traceModuleUrl)})
+    const { isSpanDisabled } = categoryModule.default ?? categoryModule
+    const { traceFactory } = traceModule.default ?? traceModule
+    let startedSpans = 0
+    let storageTraceCallbackRan = false
+    const span = {
+      setStatus () {},
+      recordException () {},
+      end () {},
+    }
+    const trace = traceFactory({
+      trace: {
+        getTracer: () => ({
+          startSpan: () => {
+            startedSpans += 1
+            return span
+          },
+          startActiveSpan: (_name, callback) => {
+            startedSpans += 1
+            return callback(span)
+          },
+        }),
+      },
+      SpanStatusCode: { OK: 1, ERROR: 2 },
+    })
+    const probe = {
+      storageRead: isSpanDisabled('agents.storage.read'),
+      authorizationSignIn: isSpanDisabled('agents.authorization.azure_bot_signin'),
+      userTokenClientGetToken: isSpanDisabled('agents.user_token_client.get_user_token'),
+      adapterProcess: isSpanDisabled('agents.adapter.process'),
+    }
+    trace(
+      { name: 'agents.storage.read', record: {}, end () {} },
+      () => { storageTraceCallbackRan = true }
+    )
+    probe.storageTraceStarted = startedSpans > 0
+    probe.storageTraceCallbackRan = storageTraceCallbackRan
+    process.stdout.write(JSON.stringify(probe))
+  `
+
+  const result = spawnSync(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', script], {
+    cwd: repoDir,
+    encoding: 'utf8',
+    env,
+  })
+
+  assert.strictEqual(result.status, 0, result.stderr)
+
+  return {
+    probe: JSON.parse(result.stdout) as CategoryProbe,
+    stderr: result.stderr,
+  }
+}
+
+function countOccurrences (value: string, search: string): number {
+  return value.split(search).length - 1
+}
+
+describe('disabled span categories', () => {
+  it('does not warn or disable spans when the deprecated setting is absent', () => {
+    const { probe, stderr } = runCategoryProbe()
+
+    assert.deepStrictEqual(probe, {
+      storageRead: false,
+      authorizationSignIn: false,
+      userTokenClientGetToken: false,
+      adapterProcess: false,
+      storageTraceStarted: true,
+      storageTraceCallbackRan: true,
+    })
+    assert.strictEqual(stderr.includes(DEPRECATION_WARNING), false)
+  })
+
+  it('warns once and retains category filtering when the deprecated setting is configured', () => {
+    const { probe, stderr } = runCategoryProbe('storage, authorization')
+
+    assert.deepStrictEqual(probe, {
+      storageRead: true,
+      authorizationSignIn: true,
+      userTokenClientGetToken: true,
+      adapterProcess: false,
+      storageTraceStarted: false,
+      storageTraceCallbackRan: true,
+    })
+    assert.strictEqual(countOccurrences(stderr, DEPRECATION_WARNING), 1)
+  })
+
+  it('warns about deprecation and ignores invalid categories', () => {
+    const { probe, stderr } = runCategoryProbe('not-a-category')
+
+    assert.deepStrictEqual(probe, {
+      storageRead: false,
+      authorizationSignIn: false,
+      userTokenClientGetToken: false,
+      adapterProcess: false,
+      storageTraceStarted: true,
+      storageTraceCallbackRan: true,
+    })
+    assert.strictEqual(countOccurrences(stderr, DEPRECATION_WARNING), 1)
+    assert.match(stderr, /Invalid span category "NOT-A-CATEGORY"/)
+  })
+})


### PR DESCRIPTION
Fixes #1282

## Description
This pull request deprecates the category-based span disabling mechanism in the `agents-telemetry` package and updates documentation and code to encourage the use of **OpenTelemetry parent-based samplers** for filtering spans. It introduces deprecation warnings, updates documentation to reflect the new recommended approach, and adds comprehensive tests to ensure backward compatibility and correct deprecation behavior.

**Deprecation of category-based span disabling:**

* Added deprecation warnings to the use of `AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES`, `SpanCategories`, and related APIs, instructing users to use an OpenTelemetry parent-based sampler instead (`src/observability/constants.ts`, `src/observability/category.ts`). [[1]](diffhunk://#diff-34794b372b9d5728f46dd1d4427000e1b3400463e010956d6dc9dc2fba477128R8-R16) [[2]](diffhunk://#diff-04b9ddd0b8abed745ca8c19ec9a1fc62a3f79394949f17c3ed11eea401d44277R26-R27) [[3]](diffhunk://#diff-04b9ddd0b8abed745ca8c19ec9a1fc62a3f79394949f17c3ed11eea401d44277R68-R69)

**Documentation updates:**

* Updated `README.md` to document the new sampler-based filtering approach, provide an example implementation, and mark the old environment variable as deprecated. Also clarified the migration path and updated feature lists accordingly. [[1]](diffhunk://#diff-54c3614a29f926232c1607054b485831d12691bd6a77ad3cf03969196b4311f9L20-R20) [[2]](diffhunk://#diff-54c3614a29f926232c1607054b485831d12691bd6a77ad3cf03969196b4311f9L96-R148) [[3]](diffhunk://#diff-54c3614a29f926232c1607054b485831d12691bd6a77ad3cf03969196b4311f9L245-R278) [[4]](diffhunk://#diff-54c3614a29f926232c1607054b485831d12691bd6a77ad3cf03969196b4311f9L288-R321)

**Testing and backward compatibility:**

* Added new tests to verify that the deprecated setting still works as expected, emits a deprecation warning, and handles invalid categories gracefully (`test/observability/category.test.ts`).

## Testing
This image shows the deprecation warning displayed when using the `AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES` env variable to filter spans.
<img width="1820" height="235" alt="image" src="https://github.com/user-attachments/assets/7990d74d-14ac-41dc-87cc-2c0cde17f7ac" />

